### PR TITLE
Fix importMap paths

### DIFF
--- a/src/app/(payload)/admin/[[...segments]]/importMap.js
+++ b/src/app/(payload)/admin/[[...segments]]/importMap.js
@@ -1,4 +1,4 @@
-import { default as default_0a69a7e871c866170247845ddb304686 } from '../../../views/Dashboard'
+import { default as default_0a69a7e871c866170247845ddb304686 } from '../../../../views/Dashboard'
 
 export const importMap = {
   "./views/Dashboard": default_0a69a7e871c866170247845ddb304686

--- a/src/app/(payload)/admin/[[...segments]]/not-found.tsx
+++ b/src/app/(payload)/admin/[[...segments]]/not-found.tsx
@@ -4,7 +4,7 @@ import type { Metadata } from 'next'
 
 import config from '@payload-config'
 import { NotFoundPage, generatePageMetadata } from '@payloadcms/next/views'
-import { importMap } from '../importMap'
+import { importMap } from './importMap'
 
 type Args = {
   params: Promise<{

--- a/src/app/(payload)/admin/[[...segments]]/page.tsx
+++ b/src/app/(payload)/admin/[[...segments]]/page.tsx
@@ -4,7 +4,7 @@ import type { Metadata } from 'next'
 
 import config from '@payload-config'
 import { RootPage, generatePageMetadata } from '@payloadcms/next/views'
-import { importMap } from '../importMap'
+import { importMap } from './importMap'
 
 type Args = {
   params: Promise<{

--- a/src/app/(payload)/layout.tsx
+++ b/src/app/(payload)/layout.tsx
@@ -6,7 +6,7 @@ import type { ServerFunctionClient } from 'payload'
 import { handleServerFunctions, RootLayout } from '@payloadcms/next/layouts'
 import React from 'react'
 
-import { importMap } from './admin/importMap.js'
+import { importMap } from './admin/[[...segments]]/importMap.js'
 import './custom.scss'
 
 type Args = {


### PR DESCRIPTION
## Summary
- fix build path for payload admin import map
- correct admin page imports

## Testing
- `npm install` *(fails: network access blocked)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685abadf44888324807b70543c53fedb