### PR TITLE
Add lead behavior tracking API

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ GET  /api/analytics         // Business analytics
 POST /api/checkout/diy      // $50 DIY package
 POST /api/checkout/upgrade  // $100/$1500 packages
 POST /api/webhook           // Stripe webhook handler
+POST /api/update-lead-behavior // Update lead behavior analytics
 ```
 
 ### **Admin Endpoints**

--- a/src/app/api/update-lead-behavior/route.ts
+++ b/src/app/api/update-lead-behavior/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server';
+import payload from 'payload';
+
+export async function POST(req: NextRequest) {
+  try {
+    const { leadId, behaviorData } = await req.json();
+
+    if (!leadId) {
+      return NextResponse.json({ error: 'Lead ID is required' }, { status: 400 });
+    }
+
+    await payload.update({
+      collection: 'leads',
+      id: leadId,
+      data: {
+        timeOnSite: behaviorData.timeOnSite?.toString(),
+        pagesViewed: behaviorData.pageViews,
+        deviceType: behaviorData.deviceType,
+        scrollDepth: behaviorData.scrollDepth,
+        clickThroughs: behaviorData.clickThroughs,
+      },
+    });
+
+    console.log(`📊 Updated behavior data for lead ${leadId}`);
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Error updating lead behavior:', error);
+    return NextResponse.json(
+      { error: 'Failed to update lead behavior' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/collections/Leads.ts
+++ b/src/collections/Leads.ts
@@ -275,15 +275,27 @@ const Leads: CollectionConfig = {
       label: 'Time on Site',
       admin: { description: 'How long they spent on the website before converting' }
     },
-    { 
-      name: 'pagesViewed', 
-      type: 'number', 
+    {
+      name: 'pagesViewed',
+      type: 'number',
       label: 'Pages Viewed',
       admin: { description: 'Number of pages viewed before converting' }
     },
-    { 
-      name: 'deviceType', 
-      type: 'select', 
+    {
+      name: 'scrollDepth',
+      type: 'number',
+      label: 'Max Scroll Depth',
+      admin: { description: 'Highest percentage scrolled on the site' }
+    },
+    {
+      name: 'clickThroughs',
+      type: 'number',
+      label: 'CTA Clicks',
+      admin: { description: 'Number of call-to-action clicks' }
+    },
+    {
+      name: 'deviceType',
+      type: 'select',
       label: 'Device Type',
       options: [
         { label: 'Desktop', value: 'desktop' },
@@ -363,7 +375,8 @@ const Leads: CollectionConfig = {
 
           // Update email tracking
           const updateEmailStatus = async (status: string) => {
-            await fetch('/api/update-lead-email-status', {
+            const baseUrl = process.env.NEXT_PUBLIC_SERVER_URL || 'http://localhost:3000';
+            await fetch(`${baseUrl}/api/update-lead-email-status`, {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({


### PR DESCRIPTION
## Summary
- track user behavior via new `/api/update-lead-behavior` endpoint
- store scroll depth and CTA clicks for each lead
- document new endpoint
- fix email status update URL

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e3c4af5a48324800e81149679184a