### PR TITLE
Finish site: Header, Footer, Privacy, Terms, Disclaimer, About, Contact

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@heroicons/react": "^2.2.0",
         "@hookform/resolvers": "^3.10.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@payloadcms/db-mongodb": "^3.43.0",
         "@payloadcms/next": "^3.43.0",
         "@payloadcms/payload-cloud": "^3.43.0",
@@ -1578,6 +1579,18 @@
         "react": ">= 16 || ^19.0.0-rc"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@hookform/resolvers": {
       "version": "3.10.0",
       "license": "MIT",
@@ -2030,40 +2043,75 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.13.2",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "ajv": "^6.12.6",
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
         "cors": "^2.8.5",
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
-        "express": "^5.0.1",
-        "express-rate-limit": "^7.5.0",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.24.1"
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/express-rate-limit": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
-      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
-      "peer": true,
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/express-rate-limit"
       },
       "peerDependencies": {
-        "express": ">= 4.11"
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/@monaco-editor/loader": {
       "version": "1.5.0",
@@ -3940,6 +3988,7 @@
     },
     "node_modules/@types/react": {
       "version": "19.1.8",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -3947,7 +3996,7 @@
     },
     "node_modules/@types/react-dom": {
       "version": "19.1.6",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -4312,8 +4361,9 @@
     },
     "node_modules/accepts": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-types": "^3.0.0",
         "negotiator": "^1.0.0"
@@ -4342,6 +4392,7 @@
     },
     "node_modules/ajv": {
       "version": "6.12.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -4353,6 +4404,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/amazon-cognito-identity-js": {
       "version": "6.3.15",
@@ -4705,22 +4795,27 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.0",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^1.0.5",
-        "debug": "^4.4.0",
+        "debug": "^4.4.3",
         "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
+        "iconv-lite": "^0.7.0",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/body-scroll-lock": {
@@ -4785,8 +4880,9 @@
     },
     "node_modules/bytes": {
       "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -5138,20 +5234,23 @@
       }
     },
     "node_modules/content-disposition": {
-      "version": "1.0.0",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/content-type": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -5163,30 +5262,37 @@
     },
     "node_modules/cookie": {
       "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.6.0"
       }
     },
     "node_modules/cors": {
-      "version": "2.8.5",
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "object-assign": "^4",
         "vary": "^1"
       },
       "engines": {
         "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/cosmiconfig": {
@@ -5323,7 +5429,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.1",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -5395,8 +5503,9 @@
     },
     "node_modules/depd": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -5524,8 +5633,9 @@
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
-      "license": "MIT",
-      "peer": true
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -5534,8 +5644,9 @@
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -6254,8 +6365,9 @@
     },
     "node_modules/etag": {
       "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -6270,8 +6382,9 @@
     },
     "node_modules/eventsource": {
       "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "eventsource-parser": "^3.0.1"
       },
@@ -6280,25 +6393,28 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.3",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/express": {
-      "version": "5.1.0",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
-        "body-parser": "^2.2.0",
+        "body-parser": "^2.2.1",
         "content-disposition": "^1.0.0",
         "content-type": "^1.0.5",
         "cookie": "^0.7.1",
         "cookie-signature": "^1.2.1",
         "debug": "^4.4.0",
+        "depd": "^2.0.0",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
@@ -6326,6 +6442,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/fast-base64-decode": {
@@ -6370,6 +6504,7 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -6489,9 +6624,10 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "2.1.0",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "encodeurl": "^2.0.0",
@@ -6501,7 +6637,11 @@
         "statuses": "^2.0.1"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-root": {
@@ -6575,8 +6715,9 @@
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -6608,8 +6749,9 @@
     },
     "node_modules/fresh": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -6918,6 +7060,15 @@
         "react-is": "^16.7.0"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-to-text": {
       "version": "9.0.5",
       "license": "MIT",
@@ -6950,26 +7101,23 @@
       }
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/http-errors/node_modules/statuses": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/http-status": {
@@ -6981,14 +7129,19 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ieee754": {
@@ -7070,6 +7223,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -7368,8 +7530,9 @@
     },
     "node_modules/is-promise": {
       "version": "4.0.0",
-      "license": "MIT",
-      "peer": true
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
@@ -7535,16 +7698,6 @@
         }
       }
     },
-    "node_modules/isomorphic.js": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
-      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
-      "peer": true,
-      "funding": {
-        "type": "GitHub Sponsors ❤",
-        "url": "https://github.com/sponsors/dmonad"
-      }
-    },
     "node_modules/isows": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
@@ -7663,7 +7816,14 @@
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
+      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -7766,27 +7926,6 @@
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.28.0.tgz",
       "integrity": "sha512-dLE3O1PZg0TlZxRQo9YDpjCjDUj8zluGyBO9MHdjo21qZmMUNrxQPeCRt8fn2s5l4HKYFQ1YNgl7k1pOJB/vZQ=="
-    },
-    "node_modules/lib0": {
-      "version": "0.2.114",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.114.tgz",
-      "integrity": "sha512-gcxmNFzA4hv8UYi8j43uPlQ7CGcyMJ2KQb5kZASw6SnAKAf10hK12i2fjrS3Cl/ugZa5Ui6WwIu1/6MIXiHttQ==",
-      "peer": true,
-      "dependencies": {
-        "isomorphic.js": "^0.2.4"
-      },
-      "bin": {
-        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
-        "0gentesthtml": "bin/gentesthtml.js",
-        "0serve": "bin/0serve.js"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "type": "GitHub Sponsors ❤",
-        "url": "https://github.com/sponsors/dmonad"
-      }
     },
     "node_modules/lightningcss": {
       "version": "1.30.1",
@@ -8044,8 +8183,9 @@
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -8062,8 +8202,9 @@
     },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -8586,21 +8727,27 @@
     },
     "node_modules/mime-db": {
       "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "3.0.1",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-db": "^1.54.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/minimatch": {
@@ -8653,12 +8800,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/monaco-editor": {
-      "version": "0.52.2",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
-      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
-      "peer": true
     },
     "node_modules/mongodb": {
       "version": "6.16.0",
@@ -8845,8 +8986,9 @@
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -9096,8 +9238,9 @@
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -9254,8 +9397,9 @@
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -9519,9 +9663,10 @@
       "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA=="
     },
     "node_modules/pkce-challenge": {
-      "version": "5.0.0",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -9636,8 +9781,9 @@
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
@@ -9648,8 +9794,9 @@
     },
     "node_modules/proxy-addr/node_modules/ipaddr.js": {
       "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -9671,7 +9818,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -9720,24 +9869,26 @@
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.0",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
       }
     },
     "node_modules/react": {
@@ -10084,8 +10235,9 @@
     },
     "node_modules/router": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "depd": "^2.0.0",
@@ -10098,11 +10250,13 @@
       }
     },
     "node_modules/router/node_modules/path-to-regexp": {
-      "version": "8.2.0",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=16"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/run-parallel": {
@@ -10212,8 +10366,9 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "license": "MIT",
-      "peer": true
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/sanitize-filename": {
       "version": "1.6.3",
@@ -10275,30 +10430,36 @@
       }
     },
     "node_modules/send": {
-      "version": "1.2.0",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "debug": "^4.3.5",
+        "debug": "^4.4.3",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
         "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "mime-types": "^3.0.1",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
         "ms": "^2.1.3",
         "on-finished": "^2.4.1",
         "range-parser": "^1.2.1",
-        "statuses": "^2.0.1"
+        "statuses": "^2.0.2"
       },
       "engines": {
         "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/serve-static": {
-      "version": "2.2.0",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
@@ -10307,6 +10468,10 @@
       },
       "engines": {
         "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/set-function-length": {
@@ -10354,8 +10519,9 @@
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
-      "license": "ISC",
-      "peer": true
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
     },
     "node_modules/sharp": {
       "version": "0.34.2",
@@ -10577,8 +10743,9 @@
     },
     "node_modules/statuses": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -10983,8 +11150,9 @@
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -11094,16 +11262,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -11178,7 +11364,7 @@
     },
     "node_modules/typescript": {
       "version": "5.8.3",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -11298,8 +11484,9 @@
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -11339,6 +11526,7 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -11436,8 +11624,9 @@
     },
     "node_modules/vary": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -11680,23 +11869,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/yjs": {
-      "version": "13.6.27",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.27.tgz",
-      "integrity": "sha512-OIDwaflOaq4wC6YlPBy2L6ceKeKuF7DeTxx+jPzv1FHn9tCZ0ZwSRnUBxD05E3yed46fv/FWJbvR+Ud7x0L7zw==",
-      "peer": true,
-      "dependencies": {
-        "lib0": "^0.2.99"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=8.0.0"
-      },
-      "funding": {
-        "type": "GitHub Sponsors ❤",
-        "url": "https://github.com/sponsors/dmonad"
-      }
-    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "dev": true,
@@ -11716,11 +11888,12 @@
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.24.6",
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
-      "peer": true,
       "peerDependencies": {
-        "zod": "^3.24.1"
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@heroicons/react": "^2.2.0",
     "@hookform/resolvers": "^3.10.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@payloadcms/db-mongodb": "^3.43.0",
     "@payloadcms/next": "^3.43.0",
     "@payloadcms/payload-cloud": "^3.43.0",

--- a/src/app/(web)/about/page.tsx
+++ b/src/app/(web)/about/page.tsx
@@ -1,0 +1,183 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+export const metadata: Metadata = {
+  title: 'About Us | Wipe That Record',
+  description:
+    'Learn about The Berhe Law Firm, the California attorneys behind Wipe That Record, and our mission to make expungement affordable and accessible.',
+  alternates: { canonical: '/about' },
+}
+
+const stats = [
+  { value: '1,847+', label: 'Californians Served' },
+  { value: '98.7%', label: 'Success Rate on Eligible Cases' },
+  { value: '21', label: 'Average Days to Approval' },
+  { value: '$50', label: 'Starting Price for DIY' },
+]
+
+const values = [
+  {
+    title: 'Access over gatekeeping',
+    body:
+      'Traditional firms charge $1,500–$3,000 to file a single expungement. We built a tiered system so people who can do the work themselves pay $97 — not thousands.',
+    icon: '🔓',
+  },
+  {
+    title: 'Honesty about outcomes',
+    body:
+      'We will tell you if your case is unlikely to be granted before you pay. A clean refund beats a bad filing.',
+    icon: '🎯',
+  },
+  {
+    title: 'California specialists',
+    body:
+      'We do one thing — California criminal record relief — and we do it under Penal Code §1203.4, Prop 47, and SB 731.',
+    icon: '⚖️',
+  },
+]
+
+export default function About() {
+  return (
+    <main className="bg-white dark:bg-slate-900">
+      {/* Hero */}
+      <section className="bg-gradient-to-br from-blue-50 via-white to-blue-50 dark:from-slate-900 dark:via-slate-900 dark:to-slate-800 py-20 px-4">
+        <div className="max-w-4xl mx-auto text-center">
+          <p className="inline-block bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 text-xs font-semibold uppercase tracking-wider px-3 py-1 rounded-full mb-5">
+            About Wipe That Record
+          </p>
+          <h1 className="text-4xl sm:text-5xl font-bold text-slate-900 dark:text-white mb-6 leading-tight">
+            Clearing California records, one case at a time.
+          </h1>
+          <p className="text-lg text-slate-700 dark:text-slate-300 max-w-2xl mx-auto leading-relaxed">
+            Wipe That Record is a service of <strong>The Berhe Law Firm, APC</strong>, a California
+            law firm based in the Inland Empire. We help Californians remove eligible convictions
+            from their record so they can get the job, the apartment, and the second chance they
+            deserve.
+          </p>
+        </div>
+      </section>
+
+      {/* Stats */}
+      <section className="py-12 border-y border-slate-200 dark:border-slate-800">
+        <div className="max-w-5xl mx-auto px-4">
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-8">
+            {stats.map((s) => (
+              <div key={s.label} className="text-center">
+                <div className="text-3xl md:text-4xl font-bold text-blue-600 dark:text-blue-400 mb-1">
+                  {s.value}
+                </div>
+                <div className="text-sm text-slate-600 dark:text-slate-400">{s.label}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Attorney */}
+      <section className="py-20 px-4">
+        <div className="max-w-4xl mx-auto">
+          <div className="grid md:grid-cols-3 gap-10 items-start">
+            <div className="md:col-span-1">
+              <div className="aspect-[3/4] rounded-2xl bg-gradient-to-br from-blue-600 to-blue-800 flex items-center justify-center text-white">
+                <div className="text-center px-4">
+                  <div className="text-6xl mb-3">⚖️</div>
+                  <p className="font-semibold">Tamerat S. Berhe, Esq.</p>
+                  <p className="text-blue-200 text-sm mt-1">CA Bar No. 298992</p>
+                </div>
+              </div>
+            </div>
+            <div className="md:col-span-2">
+              <h2 className="text-3xl font-bold text-slate-900 dark:text-white mb-4">
+                Meet your attorney
+              </h2>
+              <p className="text-slate-700 dark:text-slate-300 mb-4 leading-relaxed">
+                <strong>Tamerat &ldquo;Tam&rdquo; Berhe</strong> is the founder of The Berhe Law
+                Firm, APC, a California law firm serving the Inland Empire and all 58 California
+                counties. He is admitted to practice in California (Bar No. 298992) and focuses on
+                criminal record relief, personal injury, and estate planning.
+              </p>
+              <p className="text-slate-700 dark:text-slate-300 mb-4 leading-relaxed">
+                After watching too many clients lose jobs and housing over old, minor convictions,
+                he built Wipe That Record to make expungement accessible to people who can&rsquo;t
+                afford a $3,000 retainer.
+              </p>
+              <div className="flex flex-wrap gap-3 mt-6">
+                <a
+                  href="https://apps.calbar.ca.gov/attorney/Licensee/Detail/298992"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-2 text-sm font-medium text-blue-600 dark:text-blue-400 hover:underline"
+                >
+                  Verify CA Bar status
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                  </svg>
+                </a>
+                <a
+                  href="https://berhelaw.com"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-2 text-sm font-medium text-blue-600 dark:text-blue-400 hover:underline"
+                >
+                  Visit The Berhe Law Firm
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                  </svg>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Values */}
+      <section className="py-20 px-4 bg-slate-50 dark:bg-slate-800/50">
+        <div className="max-w-5xl mx-auto">
+          <h2 className="text-3xl font-bold text-center text-slate-900 dark:text-white mb-12">
+            What we believe
+          </h2>
+          <div className="grid md:grid-cols-3 gap-8">
+            {values.map((v) => (
+              <div
+                key={v.title}
+                className="bg-white dark:bg-slate-900 rounded-2xl p-8 shadow-sm border border-slate-200 dark:border-slate-700"
+              >
+                <div className="text-4xl mb-4">{v.icon}</div>
+                <h3 className="text-lg font-bold text-slate-900 dark:text-white mb-3">{v.title}</h3>
+                <p className="text-slate-700 dark:text-slate-300 leading-relaxed text-sm">
+                  {v.body}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-20 px-4">
+        <div className="max-w-3xl mx-auto text-center">
+          <h2 className="text-3xl font-bold text-slate-900 dark:text-white mb-4">
+            Ready to clear your record?
+          </h2>
+          <p className="text-slate-700 dark:text-slate-300 mb-8">
+            Take our 2-minute eligibility check to see which option fits your case.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <Link
+              href="/#plans"
+              className="bg-blue-600 hover:bg-blue-700 text-white font-semibold px-6 py-3 rounded-lg transition-colors"
+            >
+              See Pricing
+            </Link>
+            <Link
+              href="/contact"
+              className="border border-slate-300 dark:border-slate-700 hover:border-blue-600 dark:hover:border-blue-400 text-slate-900 dark:text-white font-semibold px-6 py-3 rounded-lg transition-colors"
+            >
+              Contact Us
+            </Link>
+          </div>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/src/app/(web)/contact/page.tsx
+++ b/src/app/(web)/contact/page.tsx
@@ -1,0 +1,234 @@
+'use client'
+
+import { useState } from 'react'
+import { motion } from 'framer-motion'
+
+export default function Contact() {
+  const [status, setStatus] = useState<'idle' | 'sending' | 'success' | 'error'>('idle')
+  const [error, setError] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    setStatus('sending')
+    setError('')
+
+    const form = e.currentTarget
+    const data = new FormData(form)
+    const payload = {
+      name: data.get('name'),
+      email: data.get('email'),
+      phone: data.get('phone'),
+      subject: data.get('subject'),
+      message: data.get('message'),
+      source: 'contact-page',
+    }
+
+    try {
+      const res = await fetch('/api/lead', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      if (!res.ok) throw new Error('Failed to send')
+      setStatus('success')
+      form.reset()
+    } catch (err) {
+      console.error(err)
+      setStatus('error')
+      setError('Something went wrong. Please call us at (909) 609-6685.')
+    }
+  }
+
+  return (
+    <main className="bg-white dark:bg-slate-900 min-h-screen">
+      {/* Hero */}
+      <section className="bg-gradient-to-br from-blue-50 via-white to-blue-50 dark:from-slate-900 dark:via-slate-900 dark:to-slate-800 py-16 px-4">
+        <div className="max-w-4xl mx-auto text-center">
+          <h1 className="text-4xl sm:text-5xl font-bold text-slate-900 dark:text-white mb-4">
+            Get in touch
+          </h1>
+          <p className="text-lg text-slate-700 dark:text-slate-300 max-w-2xl mx-auto">
+            Have a question about your case, our pricing, or the expungement process? Send us a
+            message — we usually reply within one business day.
+          </p>
+        </div>
+      </section>
+
+      <section className="py-16 px-4">
+        <div className="max-w-6xl mx-auto grid lg:grid-cols-3 gap-10">
+          {/* Contact info */}
+          <div className="lg:col-span-1 space-y-6">
+            <div>
+              <h2 className="text-lg font-bold text-slate-900 dark:text-white mb-3">Office</h2>
+              <p className="text-slate-700 dark:text-slate-300 text-sm leading-relaxed">
+                The Berhe Law Firm, APC
+                <br />
+                901 Via Piemonte, Suite 230
+                <br />
+                Ontario, CA 91764
+              </p>
+            </div>
+
+            <div>
+              <h2 className="text-lg font-bold text-slate-900 dark:text-white mb-3">Phone</h2>
+              <a
+                href="tel:+19096096685"
+                className="text-blue-600 dark:text-blue-400 hover:underline text-sm font-medium"
+              >
+                (909) 609-6685
+              </a>
+              <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+                Mon–Fri, 9 AM – 6 PM Pacific
+              </p>
+            </div>
+
+            <div>
+              <h2 className="text-lg font-bold text-slate-900 dark:text-white mb-3">Email</h2>
+              <a
+                href="mailto:support@wipethatrecord.com"
+                className="text-blue-600 dark:text-blue-400 hover:underline text-sm font-medium break-all"
+              >
+                support@wipethatrecord.com
+              </a>
+            </div>
+
+            <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-xl p-4">
+              <p className="text-sm text-slate-700 dark:text-slate-200 leading-relaxed">
+                <strong className="text-slate-900 dark:text-white">Important:</strong> Contacting
+                us through this form does not create an attorney-client relationship. Please do
+                not send confidential information about your case until you have a signed
+                engagement agreement with us.
+              </p>
+            </div>
+          </div>
+
+          {/* Form */}
+          <div className="lg:col-span-2">
+            <motion.form
+              onSubmit={handleSubmit}
+              className="bg-white dark:bg-slate-800/50 border border-slate-200 dark:border-slate-700 rounded-2xl p-6 sm:p-8 shadow-sm"
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+            >
+              {status === 'success' ? (
+                <div className="text-center py-12">
+                  <div className="text-5xl mb-4">✅</div>
+                  <h3 className="text-2xl font-bold text-slate-900 dark:text-white mb-2">
+                    Message sent
+                  </h3>
+                  <p className="text-slate-700 dark:text-slate-300">
+                    Thanks for reaching out. We&rsquo;ll get back to you within one business day.
+                  </p>
+                </div>
+              ) : (
+                <>
+                  <div className="grid sm:grid-cols-2 gap-4 mb-4">
+                    <div>
+                      <label
+                        htmlFor="name"
+                        className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1.5"
+                      >
+                        Full name
+                      </label>
+                      <input
+                        id="name"
+                        name="name"
+                        type="text"
+                        required
+                        className="w-full px-3 py-2.5 rounded-lg border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      />
+                    </div>
+                    <div>
+                      <label
+                        htmlFor="email"
+                        className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1.5"
+                      >
+                        Email
+                      </label>
+                      <input
+                        id="email"
+                        name="email"
+                        type="email"
+                        required
+                        className="w-full px-3 py-2.5 rounded-lg border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      />
+                    </div>
+                  </div>
+
+                  <div className="grid sm:grid-cols-2 gap-4 mb-4">
+                    <div>
+                      <label
+                        htmlFor="phone"
+                        className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1.5"
+                      >
+                        Phone <span className="text-slate-400 font-normal">(optional)</span>
+                      </label>
+                      <input
+                        id="phone"
+                        name="phone"
+                        type="tel"
+                        className="w-full px-3 py-2.5 rounded-lg border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      />
+                    </div>
+                    <div>
+                      <label
+                        htmlFor="subject"
+                        className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1.5"
+                      >
+                        Topic
+                      </label>
+                      <select
+                        id="subject"
+                        name="subject"
+                        defaultValue="General question"
+                        className="w-full px-3 py-2.5 rounded-lg border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      >
+                        <option>General question</option>
+                        <option>Eligibility check</option>
+                        <option>DIY kit support</option>
+                        <option>Refund request</option>
+                        <option>Press / media</option>
+                        <option>Other</option>
+                      </select>
+                    </div>
+                  </div>
+
+                  <div className="mb-5">
+                    <label
+                      htmlFor="message"
+                      className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1.5"
+                    >
+                      Message
+                    </label>
+                    <textarea
+                      id="message"
+                      name="message"
+                      rows={6}
+                      required
+                      placeholder="Briefly describe your question. Please do not share confidential case details."
+                      className="w-full px-3 py-2.5 rounded-lg border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-y"
+                    />
+                  </div>
+
+                  {status === 'error' && (
+                    <div className="mb-4 p-3 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded-lg text-sm text-red-700 dark:text-red-300">
+                      {error}
+                    </div>
+                  )}
+
+                  <button
+                    type="submit"
+                    disabled={status === 'sending'}
+                    className="w-full sm:w-auto bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 text-white font-semibold px-6 py-3 rounded-lg transition-colors"
+                  >
+                    {status === 'sending' ? 'Sending…' : 'Send message'}
+                  </button>
+                </>
+              )}
+            </motion.form>
+          </div>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/src/app/(web)/disclaimer/page.tsx
+++ b/src/app/(web)/disclaimer/page.tsx
@@ -1,0 +1,121 @@
+import type { Metadata } from 'next'
+import { LegalPage } from '@/components/LegalPage'
+
+export const metadata: Metadata = {
+  title: 'Legal Disclaimer | Wipe That Record',
+  description:
+    'Important legal disclaimers regarding the information and services available on wipethatrecord.com.',
+  alternates: { canonical: '/disclaimer' },
+}
+
+export default function Disclaimer() {
+  return (
+    <LegalPage title="Legal Disclaimer" updated="June 5, 2026">
+      <h2>Attorney Advertising</h2>
+      <p>
+        This website is an advertisement for legal services. The information provided on{' '}
+        <a href="https://wipethatrecord.com">wipethatrecord.com</a> (the &ldquo;Site&rdquo;) is
+        published by The Berhe Law Firm, APC. The attorney responsible for the content of this Site
+        is <strong>Tamerat S. Berhe</strong>, California State Bar No. 298992, with offices at 901
+        Via Piemonte, Suite 230, Ontario, CA 91764.
+      </p>
+
+      <h2>Not Legal Advice</h2>
+      <p>
+        Nothing on this Site constitutes legal advice or a legal opinion. The information is
+        provided for general educational and informational purposes only. The law changes
+        frequently and varies by jurisdiction and individual facts. <strong>You should not act or
+        rely on any information on this Site without seeking the advice of a qualified attorney
+        licensed in your state.</strong>
+      </p>
+
+      <h2>No Attorney-Client Relationship</h2>
+      <p>
+        Use of this Site, purchase of the DIY Expungement Kit, submission of an eligibility
+        questionnaire, or contact through the Site does <strong>not</strong> create an
+        attorney-client relationship between you and The Berhe Law Firm, APC. An attorney-client
+        relationship is formed only upon execution of a written engagement agreement and payment
+        of any applicable retainer.
+      </p>
+      <p>
+        Communications sent through the Site or by email are not necessarily confidential or
+        protected by the attorney-client privilege until an engagement agreement is in place.
+        Please do not send sensitive or confidential information through unsecured channels.
+      </p>
+
+      <h2>DIY Service Is Not Legal Representation</h2>
+      <p>
+        The DIY Expungement Kit and Expert Review options are{' '}
+        <strong>self-help legal products</strong>. They provide educational materials, court forms,
+        and assistance with form completion, but they do not constitute legal representation. If
+        you purchase one of these tiers:
+      </p>
+      <ul>
+        <li>You are representing yourself in court (pro se / pro per).</li>
+        <li>We do not appear on your behalf or sign documents as your attorney of record.</li>
+        <li>
+          You are responsible for filing documents, meeting court deadlines, attending hearings,
+          and complying with all procedural rules.
+        </li>
+      </ul>
+      <p>
+        Full attorney representation is available through our <strong>Full Service</strong> tier
+        and requires a separate signed engagement agreement.
+      </p>
+
+      <h2>No Guarantee of Outcome</h2>
+      <p>
+        Statements regarding success rates, processing times, and prior client outcomes describe
+        general experience and do not guarantee a particular result in your case. Every case is
+        unique, and the outcome of any legal matter depends on the specific facts, the discretion
+        of the court, and other factors outside our control.
+      </p>
+
+      <h2>Testimonials</h2>
+      <p>
+        Testimonials and client stories on this Site are based on real experiences but have been
+        edited for clarity and length, and client names and likenesses may have been changed to
+        protect privacy. Past results do not predict or guarantee future outcomes.
+      </p>
+
+      <h2>External Links</h2>
+      <p>
+        This Site may contain links to third-party websites. We do not control and are not
+        responsible for the content, accuracy, or practices of those websites. Links are provided
+        for convenience and do not constitute an endorsement.
+      </p>
+
+      <h2>Jurisdiction</h2>
+      <p>
+        The Berhe Law Firm, APC is licensed to practice law only in the State of California. We
+        accept matters only involving California courts and California state law. If you reside
+        outside California or need representation in another jurisdiction, please consult a
+        licensed attorney in your state.
+      </p>
+
+      <h2>Contact</h2>
+      <p>
+        <strong>The Berhe Law Firm, APC</strong>
+        <br />
+        Attorney Tamerat S. Berhe — CA Bar No. 298992
+        <br />
+        901 Via Piemonte, Suite 230
+        <br />
+        Ontario, CA 91764
+        <br />
+        Phone: <a href="tel:+19096096685">(909) 609-6685</a>
+        <br />
+        Email: <a href="mailto:support@wipethatrecord.com">support@wipethatrecord.com</a>
+        <br />
+        Bar verification:{' '}
+        <a
+          href="https://apps.calbar.ca.gov/attorney/Licensee/Detail/298992"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          State Bar of California profile
+        </a>
+      </p>
+    </LegalPage>
+  )
+}

--- a/src/app/(web)/layout.tsx
+++ b/src/app/(web)/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Analytics from "@/components/Analytics";
+import { Header } from "@/components/Header";
+import { Footer } from "@/components/Footer";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -63,7 +65,7 @@ export const metadata: Metadata = {
     },
   },
   verification: {
-    google: "your-google-verification-code",
+    google: process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION ?? undefined,
   },
 };
 
@@ -112,7 +114,9 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <Analytics />
+        <Header />
         {children}
+        <Footer />
       </body>
     </html>
   );

--- a/src/app/(web)/page.tsx
+++ b/src/app/(web)/page.tsx
@@ -130,11 +130,11 @@ export default function LandingPage() {
         </motion.div>
       )}
 
-      {/* Sticky notification bar */}
+      {/* Promo notification bar (rendered below the global header) */}
       <motion.div 
         initial={{ y: -100 }}
         animate={{ y: 0 }}
-        className="sticky top-0 z-40 bg-gradient-to-r from-amber-400 to-amber-500 text-slate-900 text-center py-2 px-4"
+        className="relative z-20 bg-gradient-to-r from-amber-400 to-amber-500 text-slate-900 text-center py-2 px-4"
       >
         <p className="text-sm font-semibold">
           🔥 Limited Time: DIY Expungement Kit - Only $97 (Save $50) | 

--- a/src/app/(web)/privacy/page.tsx
+++ b/src/app/(web)/privacy/page.tsx
@@ -1,0 +1,177 @@
+import type { Metadata } from 'next'
+import { LegalPage } from '@/components/LegalPage'
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy | Wipe That Record',
+  description:
+    'How Wipe That Record collects, uses, and protects your personal information when you use our California expungement service.',
+  alternates: { canonical: '/privacy' },
+}
+
+export default function PrivacyPolicy() {
+  return (
+    <LegalPage title="Privacy Policy" updated="June 5, 2026">
+      <p>
+        Wipe That Record (&ldquo;<strong>we</strong>,&rdquo; &ldquo;<strong>our</strong>,&rdquo; or
+        &ldquo;<strong>us</strong>&rdquo;), operated by The Berhe Law Firm, APC, respects your privacy.
+        This Privacy Policy explains what information we collect, how we use it, and the choices you
+        have regarding your personal information when you use{' '}
+        <a href="https://wipethatrecord.com">wipethatrecord.com</a> (the &ldquo;Site&rdquo;) and our
+        related services (collectively, the &ldquo;Services&rdquo;).
+      </p>
+
+      <h2>1. Information We Collect</h2>
+
+      <h3>Information You Provide</h3>
+      <ul>
+        <li>
+          <strong>Contact information</strong> — name, email address, phone number, and mailing
+          address when you sign up, request an eligibility check, or contact us.
+        </li>
+        <li>
+          <strong>Case information</strong> — facts about your criminal record (charges,
+          convictions, dates, county, sentencing) provided through our questionnaires.
+        </li>
+        <li>
+          <strong>Payment information</strong> — credit card details and billing address are
+          collected and processed by our payment processor, Stripe. We do not store full card
+          numbers on our servers.
+        </li>
+        <li>
+          <strong>Communications</strong> — messages you send to us by email, contact form, SMS, or
+          phone, and recordings or transcripts of consultation calls when permitted by law.
+        </li>
+      </ul>
+
+      <h3>Information Collected Automatically</h3>
+      <ul>
+        <li>IP address, device type, browser type, and operating system.</li>
+        <li>Pages visited, referring URL, click data, and session duration.</li>
+        <li>Cookies and similar technologies (see &ldquo;Cookies&rdquo; below).</li>
+      </ul>
+
+      <h2>2. How We Use Your Information</h2>
+      <ul>
+        <li>Evaluate eligibility for expungement and prepare your case documents.</li>
+        <li>Process payments and deliver the Services you purchased.</li>
+        <li>Communicate with you about your case, scheduling, and account updates.</li>
+        <li>
+          Send marketing communications (you may opt out at any time via the unsubscribe link in
+          any email or by visiting our <a href="/unsubscribe">unsubscribe page</a>).
+        </li>
+        <li>Improve and secure the Site, prevent fraud, and comply with legal obligations.</li>
+      </ul>
+
+      <h2>3. Attorney-Client Confidentiality</h2>
+      <p>
+        Information you submit specifically in the course of receiving legal services from The Berhe
+        Law Firm, APC is protected by the attorney-client privilege and California Rule of
+        Professional Conduct 1.6, in addition to this Privacy Policy. Submitting information through
+        this Site alone does <strong>not</strong> create an attorney-client relationship — that
+        relationship is formed only by a signed engagement agreement with the firm.
+      </p>
+
+      <h2>4. How We Share Information</h2>
+      <p>
+        We do not sell your personal information. We share it only as follows:
+      </p>
+      <ul>
+        <li>
+          <strong>Service providers</strong> — Stripe (payments), Resend and SendGrid (email),
+          Supabase and MongoDB Atlas (database hosting), Vercel (web hosting), Twilio (SMS), and
+          analytics providers. These vendors are contractually bound to protect your data.
+        </li>
+        <li>
+          <strong>Courts and government agencies</strong> — required filings with California
+          Superior Courts, the California Department of Justice, and the FBI when necessary to
+          perform the Services.
+        </li>
+        <li>
+          <strong>Legal requirements</strong> — to comply with a subpoena, court order, or other
+          legal process, or to protect our rights, property, or safety.
+        </li>
+        <li>
+          <strong>Business transfers</strong> — in connection with a merger, acquisition, or sale of
+          assets, subject to confidentiality protections.
+        </li>
+      </ul>
+
+      <h2>5. Cookies and Tracking</h2>
+      <p>
+        We use cookies and similar technologies to operate the Site, remember your preferences, and
+        analyze traffic. You can disable cookies in your browser, but parts of the Site may not
+        function correctly. We also use Google Analytics; you can opt out using the{' '}
+        <a href="https://tools.google.com/dlpage/gaoptout" target="_blank" rel="noopener noreferrer">
+          Google Analytics opt-out browser add-on
+        </a>
+        .
+      </p>
+
+      <h2>6. Data Retention</h2>
+      <p>
+        We retain personal information for as long as needed to provide the Services, comply with
+        our legal obligations (including California Rules of Professional Conduct, which require
+        client files to be retained for at least 5 years after the matter closes), resolve disputes,
+        and enforce our agreements.
+      </p>
+
+      <h2>7. Security</h2>
+      <p>
+        We use industry-standard administrative, technical, and physical safeguards — including TLS
+        encryption in transit, encryption at rest, role-based access controls, and regular reviews
+        — to protect your information. No system is 100% secure, however, and we cannot guarantee
+        absolute security.
+      </p>
+
+      <h2>8. Your California Privacy Rights</h2>
+      <p>
+        Under the California Consumer Privacy Act (CCPA) and CPRA, California residents have the
+        right to:
+      </p>
+      <ul>
+        <li>Know what personal information we collect, use, and disclose.</li>
+        <li>Request deletion of personal information we hold about you.</li>
+        <li>Correct inaccurate personal information.</li>
+        <li>Limit use of sensitive personal information.</li>
+        <li>Opt out of the sale or sharing of personal information (we do not sell your data).</li>
+        <li>Non-discrimination for exercising your privacy rights.</li>
+      </ul>
+      <p>
+        To exercise any of these rights, email{' '}
+        <a href="mailto:privacy@wipethatrecord.com">privacy@wipethatrecord.com</a> or call{' '}
+        <a href="tel:+19096096685">(909) 609-6685</a>. We may need to verify your identity before
+        responding.
+      </p>
+
+      <h2>9. Children&rsquo;s Privacy</h2>
+      <p>
+        Our Services are not directed to children under 18, and we do not knowingly collect personal
+        information from children. If you believe we have collected information from a child,
+        please contact us so we can delete it.
+      </p>
+
+      <h2>10. Changes to This Policy</h2>
+      <p>
+        We may update this Privacy Policy from time to time. When we do, we will post the new
+        policy on this page and update the &ldquo;Last updated&rdquo; date above. Material changes
+        will be communicated by email or a prominent notice on the Site.
+      </p>
+
+      <h2>11. Contact Us</h2>
+      <p>
+        Questions about this Privacy Policy? Contact us at:
+      </p>
+      <p>
+        <strong>The Berhe Law Firm, APC</strong>
+        <br />
+        901 Via Piemonte, Suite 230
+        <br />
+        Ontario, CA 91764
+        <br />
+        Email: <a href="mailto:privacy@wipethatrecord.com">privacy@wipethatrecord.com</a>
+        <br />
+        Phone: <a href="tel:+19096096685">(909) 609-6685</a>
+      </p>
+    </LegalPage>
+  )
+}

--- a/src/app/(web)/terms/page.tsx
+++ b/src/app/(web)/terms/page.tsx
@@ -1,0 +1,172 @@
+import type { Metadata } from 'next'
+import { LegalPage } from '@/components/LegalPage'
+
+export const metadata: Metadata = {
+  title: 'Terms of Service | Wipe That Record',
+  description:
+    'The terms and conditions governing your use of wipethatrecord.com and our California expungement services.',
+  alternates: { canonical: '/terms' },
+}
+
+export default function TermsOfService() {
+  return (
+    <LegalPage title="Terms of Service" updated="June 5, 2026">
+      <p>
+        These Terms of Service (&ldquo;<strong>Terms</strong>&rdquo;) govern your use of{' '}
+        <a href="https://wipethatrecord.com">wipethatrecord.com</a> (the &ldquo;Site&rdquo;) and the
+        services offered through it (the &ldquo;Services&rdquo;), which are provided by The Berhe
+        Law Firm, APC (&ldquo;<strong>we</strong>,&rdquo; &ldquo;<strong>our</strong>,&rdquo; or
+        &ldquo;<strong>us</strong>&rdquo;). By accessing or using the Site, you agree to be bound by
+        these Terms. If you do not agree, do not use the Site.
+      </p>
+
+      <h2>1. Eligibility</h2>
+      <p>
+        You must be at least 18 years old and a resident of the United States to use the Services.
+        Our expungement services are limited to convictions that occurred in the State of
+        California.
+      </p>
+
+      <h2>2. Description of Services</h2>
+      <p>
+        We offer three service tiers for California criminal record relief:
+      </p>
+      <ul>
+        <li>
+          <strong>DIY Expungement Kit ($97):</strong> A self-service package that includes
+          California court forms, written instructions, and email support. You complete and file
+          the documents yourself.
+        </li>
+        <li>
+          <strong>Expert Review ($297):</strong> Form completion by our team, a case review, and a
+          phone consultation. You still file the documents with the court.
+        </li>
+        <li>
+          <strong>Full Service ($1,497):</strong> Full attorney representation, including
+          preparation, filing, and any required court appearances.
+        </li>
+      </ul>
+
+      <h2>3. Attorney-Client Relationship</h2>
+      <p>
+        <strong>No attorney-client relationship is created</strong> by your use of the Site, the DIY
+        Expungement Kit, by submitting an eligibility questionnaire, or by sending us an email. An
+        attorney-client relationship is formed only when you and The Berhe Law Firm, APC have
+        executed a written engagement agreement and you have paid the applicable retainer.
+      </p>
+      <p>
+        The DIY Expungement Kit is a <strong>self-help legal product</strong>, similar to those
+        offered by services such as LegalZoom and Rocket Lawyer. It is not legal advice tailored to
+        your circumstances.
+      </p>
+
+      <h2>4. Payment and Refunds</h2>
+      <ul>
+        <li>All fees are charged in U.S. dollars and processed by Stripe.</li>
+        <li>
+          <strong>Money-back guarantee:</strong> If your case does not qualify for expungement
+          based on the information you provide and our review, we will refund the purchase price in
+          full. Refund requests must be submitted within 30 days of purchase and before any court
+          filing is made on your behalf.
+        </li>
+        <li>
+          Once court filing fees have been paid to a third party (the Superior Court), those
+          fees are non-refundable because they are paid to the court, not to us.
+        </li>
+        <li>
+          <strong>Chargebacks:</strong> If you initiate a chargeback without first contacting us,
+          we reserve the right to suspend further service.
+        </li>
+      </ul>
+
+      <h2>5. Your Responsibilities</h2>
+      <p>You agree to:</p>
+      <ul>
+        <li>Provide accurate, complete, and up-to-date information.</li>
+        <li>
+          Promptly review documents we prepare and notify us of any errors before filing.
+        </li>
+        <li>Comply with all court rules, deadlines, and notice requirements.</li>
+        <li>Not use the Services for any unlawful purpose or to defraud any party.</li>
+      </ul>
+      <p>
+        Providing false or incomplete information about your criminal history may render your
+        petition defective and is, in some cases, a crime. We are not liable for outcomes that
+        result from inaccurate information you provide.
+      </p>
+
+      <h2>6. No Guarantee of Outcome</h2>
+      <p>
+        Every case is unique. While we are proud of our high success rate on eligible cases, we do
+        not and cannot guarantee that any specific petition will be granted by a court. Statements
+        about success rates, processing times, and the number of clients served on the Site are
+        provided for general informational purposes only and do not constitute a warranty.
+      </p>
+
+      <h2>7. Intellectual Property</h2>
+      <p>
+        All content on the Site — including text, graphics, logos, form templates, instructions,
+        and software — is owned by or licensed to us and is protected by United States and
+        international copyright, trademark, and other intellectual property laws. You may use the
+        DIY Expungement Kit solely for your own personal, non-commercial use. You may not resell,
+        sublicense, or redistribute any portion of our content.
+      </p>
+
+      <h2>8. Disclaimer of Warranties</h2>
+      <p>
+        THE SITE AND SERVICES ARE PROVIDED &ldquo;AS IS&rdquo; AND &ldquo;AS AVAILABLE&rdquo; WITHOUT
+        WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING WARRANTIES OF MERCHANTABILITY, FITNESS
+        FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT. We do not warrant that the Site will be
+        uninterrupted, error-free, or secure.
+      </p>
+
+      <h2>9. Limitation of Liability</h2>
+      <p>
+        TO THE FULLEST EXTENT PERMITTED BY LAW, OUR TOTAL LIABILITY ARISING OUT OF OR RELATING TO
+        THESE TERMS OR THE SERVICES SHALL NOT EXCEED THE AMOUNT YOU PAID TO US IN THE 12 MONTHS
+        BEFORE THE EVENT GIVING RISE TO THE CLAIM. WE WILL NOT BE LIABLE FOR ANY INDIRECT,
+        INCIDENTAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+        DAMAGES. This limitation does not apply to claims for legal malpractice arising out of an
+        attorney-client relationship governed by a signed engagement agreement, which are governed
+        by California law and the California Rules of Professional Conduct.
+      </p>
+
+      <h2>10. Indemnification</h2>
+      <p>
+        You agree to indemnify, defend, and hold harmless The Berhe Law Firm, APC and its
+        attorneys, employees, and agents from any claim, demand, loss, or damage (including
+        reasonable attorneys&rsquo; fees) arising out of your use of the Services, your violation
+        of these Terms, or your violation of any law or third-party right.
+      </p>
+
+      <h2>11. Governing Law and Dispute Resolution</h2>
+      <p>
+        These Terms are governed by the laws of the State of California, without regard to its
+        conflict-of-laws principles. Any dispute arising out of or relating to these Terms or the
+        Services shall be resolved exclusively in the state or federal courts located in San
+        Bernardino County, California, and you consent to the personal jurisdiction of those
+        courts.
+      </p>
+
+      <h2>12. Modifications</h2>
+      <p>
+        We may update these Terms at any time. Material changes will be communicated by email or a
+        prominent notice on the Site. Continued use of the Site after changes take effect
+        constitutes acceptance of the revised Terms.
+      </p>
+
+      <h2>13. Contact Us</h2>
+      <p>
+        <strong>The Berhe Law Firm, APC</strong>
+        <br />
+        901 Via Piemonte, Suite 230
+        <br />
+        Ontario, CA 91764
+        <br />
+        Email: <a href="mailto:support@wipethatrecord.com">support@wipethatrecord.com</a>
+        <br />
+        Phone: <a href="tel:+19096096685">(909) 609-6685</a>
+      </p>
+    </LegalPage>
+  )
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,12 +1,15 @@
-import { Inter } from 'next/font/google'
-import LocalBusinessSchema from '@/components/LocalBusinessSchema'
-import GoogleAnalytics from '@/components/GoogleAnalytics'
-
-const inter = Inter({ subsets: ['latin'] })
-
+/**
+ * Root layout for Next.js App Router.
+ *
+ * Both route groups in this app — `(payload)` and `(web)` — render their own
+ * complete `<html>`/`<body>` shells (Payload's admin UI needs full control, and
+ * the public site has its own font/meta setup). This top-level layout must
+ * exist, but it must NOT also emit `<html>` or it would produce nested
+ * document tags. It simply passes children through.
+ */
 export const metadata = {
-  title: 'WipeThatRecord - California Expungement Services',
-  description: 'Professional criminal record expungement services in California. Clear your record with experienced attorneys.',
+  title: 'Wipe That Record',
+  description: 'California criminal record expungement services.',
 }
 
 export default function RootLayout({
@@ -14,15 +17,5 @@ export default function RootLayout({
 }: {
   children: React.ReactNode
 }) {
-  return (
-    <html lang="en">
-      <head>
-        <LocalBusinessSchema />
-        <GoogleAnalytics />
-      </head>
-      <body className={inter.className}>
-        {children}
-      </body>
-    </html>
-  )
+  return children
 }

--- a/src/components/Analytics.tsx
+++ b/src/components/Analytics.tsx
@@ -6,45 +6,65 @@ import { initAnalytics } from '@/lib/analytics';
 
 interface AnalyticsProps {
   gaId?: string;
+  gtmId?: string;
+  fbPixelId?: string;
+  clarityId?: string;
+  hotjarId?: string;
 }
 
-export default function Analytics({ gaId = 'G-XXXXXXXXXX' }: AnalyticsProps) {
+/**
+ * Analytics scripts only render when an ID is explicitly provided either via
+ * props or `NEXT_PUBLIC_*` environment variables. Placeholder IDs are never
+ * injected into the page — they create broken network calls and dirty consoles.
+ */
+export default function Analytics({
+  gaId = process.env.NEXT_PUBLIC_GA_ID,
+  gtmId = process.env.NEXT_PUBLIC_GTM_ID,
+  fbPixelId = process.env.NEXT_PUBLIC_FB_PIXEL_ID,
+  clarityId = process.env.NEXT_PUBLIC_CLARITY_ID,
+  hotjarId = process.env.NEXT_PUBLIC_HOTJAR_ID,
+}: AnalyticsProps) {
   useEffect(() => {
-    // Initialize our custom analytics
     initAnalytics();
   }, []);
 
   return (
     <>
-      {/* Google Analytics */}
-      <Script
-        src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}
-        strategy="afterInteractive"
-      />
-      <Script id="google-analytics" strategy="afterInteractive">
-        {`
-          window.dataLayer = window.dataLayer || [];
-          function gtag(){dataLayer.push(arguments);}
-          gtag('js', new Date());
-          gtag('config', '${gaId}', {
-            page_title: document.title,
-            page_location: window.location.href,
-          });
-        `}
-      </Script>
+      {/* Google Analytics — only when ID provided */}
+      {gaId && (
+        <>
+          <Script
+            src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}
+            strategy="afterInteractive"
+          />
+          <Script id="google-analytics" strategy="afterInteractive">
+            {`
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
+              gtag('config', '${gaId}', {
+                page_title: document.title,
+                page_location: window.location.href,
+              });
+            `}
+          </Script>
+        </>
+      )}
 
       {/* Google Tag Manager */}
-      <Script id="google-tag-manager" strategy="afterInteractive">
-        {`
-          (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-          new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-          j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-          'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-          })(window,document,'script','dataLayer','GTM-XXXXXXXXX');
-        `}
-      </Script>
+      {gtmId && (
+        <Script id="google-tag-manager" strategy="afterInteractive">
+          {`
+            (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+            new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+            j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+            'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+            })(window,document,'script','dataLayer','${gtmId}');
+          `}
+        </Script>
+      )}
 
-      {/* Schema.org JSON-LD for SEO */}
+      {/* Schema.org JSON-LD for SEO — always safe to render */}
       <Script id="schema-org" type="application/ld+json">
         {`
           {
@@ -54,16 +74,17 @@ export default function Analytics({ gaId = 'G-XXXXXXXXXX' }: AnalyticsProps) {
             "description": "Professional expungement services in California. Clear your criminal record with our DIY kits, professional filing service, or full attorney representation.",
             "url": "https://www.wipethatrecord.com",
             "logo": "https://www.wipethatrecord.com/logo.png",
+            "telephone": "+1-909-609-6685",
             "address": {
               "@type": "PostalAddress",
+              "streetAddress": "901 Via Piemonte, Suite 230",
+              "addressLocality": "Ontario",
               "addressRegion": "CA",
+              "postalCode": "91764",
               "addressCountry": "US"
             },
             "areaServed": [
-              {
-                "@type": "State",
-                "name": "California"
-              }
+              { "@type": "State", "name": "California" }
             ],
             "serviceType": [
               "Criminal Record Expungement",
@@ -75,21 +96,21 @@ export default function Analytics({ gaId = 'G-XXXXXXXXXX' }: AnalyticsProps) {
                 "@type": "Offer",
                 "name": "DIY Self Expunge Kit",
                 "description": "Complete do-it-yourself expungement kit with forms and instructions",
-                "price": "99",
+                "price": "97",
                 "priceCurrency": "USD"
               },
               {
                 "@type": "Offer",
-                "name": "Professionally Filled & Filed Service",
+                "name": "Expert Review",
                 "description": "Professional form completion and filing guidance",
-                "price": "299",
+                "price": "297",
                 "priceCurrency": "USD"
               },
               {
                 "@type": "Offer",
                 "name": "Full Attorney Service",
                 "description": "Complete attorney-managed expungement service",
-                "price": "1500",
+                "price": "1497",
                 "priceCurrency": "USD"
               }
             ],
@@ -103,45 +124,51 @@ export default function Analytics({ gaId = 'G-XXXXXXXXXX' }: AnalyticsProps) {
       </Script>
 
       {/* Facebook Pixel */}
-      <Script id="facebook-pixel" strategy="afterInteractive">
-        {`
-          !function(f,b,e,v,n,t,s)
-          {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
-          n.callMethod.apply(n,arguments):n.queue.push(arguments)};
-          if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
-          n.queue=[];t=b.createElement(e);t.async=!0;
-          t.src=v;s=b.getElementsByTagName(e)[0];
-          s.parentNode.insertBefore(t,s)}(window, document,'script',
-          'https://connect.facebook.net/en_US/fbevents.js');
-          fbq('init', 'XXXXXXXXXXXXXXX');
-          fbq('track', 'PageView');
-        `}
-      </Script>
+      {fbPixelId && (
+        <Script id="facebook-pixel" strategy="afterInteractive">
+          {`
+            !function(f,b,e,v,n,t,s)
+            {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+            n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+            if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+            n.queue=[];t=b.createElement(e);t.async=!0;
+            t.src=v;s=b.getElementsByTagName(e)[0];
+            s.parentNode.insertBefore(t,s)}(window, document,'script',
+            'https://connect.facebook.net/en_US/fbevents.js');
+            fbq('init', '${fbPixelId}');
+            fbq('track', 'PageView');
+          `}
+        </Script>
+      )}
 
       {/* Microsoft Clarity */}
-      <Script id="microsoft-clarity" strategy="afterInteractive">
-        {`
-          (function(c,l,a,r,i,t,y){
-              c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-              t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-              y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-          })(window, document, "clarity", "script", "XXXXXXXXXX");
-        `}
-      </Script>
+      {clarityId && (
+        <Script id="microsoft-clarity" strategy="afterInteractive">
+          {`
+            (function(c,l,a,r,i,t,y){
+                c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+                t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+                y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+            })(window, document, "clarity", "script", "${clarityId}");
+          `}
+        </Script>
+      )}
 
       {/* Hotjar */}
-      <Script id="hotjar" strategy="afterInteractive">
-        {`
-          (function(h,o,t,j,a,r){
-              h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-              h._hjSettings={hjid:XXXXXXX,hjsv:6};
-              a=o.getElementsByTagName('head')[0];
-              r=o.createElement('script');r.async=1;
-              r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-              a.appendChild(r);
-          })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
-        `}
-      </Script>
+      {hotjarId && (
+        <Script id="hotjar" strategy="afterInteractive">
+          {`
+            (function(h,o,t,j,a,r){
+                h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+                h._hjSettings={hjid:${hotjarId},hjsv:6};
+                a=o.getElementsByTagName('head')[0];
+                r=o.createElement('script');r.async=1;
+                r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+                a.appendChild(r);
+            })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+          `}
+        </Script>
+      )}
     </>
   );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,119 @@
+import Link from 'next/link'
+
+export function Footer() {
+  const year = new Date().getFullYear()
+
+  return (
+    <footer className="bg-slate-900 text-slate-300 border-t border-slate-800">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-14">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-10">
+          {/* Brand & contact */}
+          <div className="lg:col-span-2">
+            <Link href="/" className="inline-flex items-center gap-2 mb-4" aria-label="Wipe That Record home">
+              <svg width="36" height="36" viewBox="0 0 36 36" fill="none" aria-hidden="true">
+                <rect x="2" y="2" width="32" height="32" rx="8" fill="#2563EB" />
+                <path
+                  d="M10 18.5L15.5 24L26 13"
+                  stroke="white"
+                  strokeWidth="3"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+              <span className="font-bold text-white text-lg">Wipe That Record</span>
+            </Link>
+            <p className="text-sm leading-relaxed text-slate-400 max-w-md mb-5">
+              California criminal record expungement services. We help Californians clear
+              eligible convictions under Penal Code §1203.4, Prop 47, and SB 731 — at a fraction
+              of traditional attorney fees.
+            </p>
+            <ul className="space-y-2 text-sm">
+              <li className="flex items-start gap-2">
+                <svg className="w-4 h-4 mt-0.5 text-blue-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a2 2 0 01-2.828 0l-4.244-4.243a8 8 0 1111.314 0z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+                </svg>
+                <span>901 Via Piemonte, Suite 230<br />Ontario, CA 91764</span>
+              </li>
+              <li className="flex items-center gap-2">
+                <svg className="w-4 h-4 text-blue-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
+                </svg>
+                <a href="tel:+19096096685" className="hover:text-white transition-colors">
+                  (909) 609-6685
+                </a>
+              </li>
+              <li className="flex items-center gap-2">
+                <svg className="w-4 h-4 text-blue-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                </svg>
+                <a href="mailto:support@wipethatrecord.com" className="hover:text-white transition-colors">
+                  support@wipethatrecord.com
+                </a>
+              </li>
+            </ul>
+          </div>
+
+          {/* Services */}
+          <div>
+            <h3 className="font-semibold text-white mb-4 text-sm uppercase tracking-wider">
+              Services
+            </h3>
+            <ul className="space-y-2 text-sm">
+              <li><Link href="/checkout/diy" className="hover:text-white transition-colors">DIY Expungement Kit</Link></li>
+              <li><Link href="/checkout/review" className="hover:text-white transition-colors">Expert Review</Link></li>
+              <li><Link href="/checkout/full-service" className="hover:text-white transition-colors">Full Attorney Service</Link></li>
+              <li><Link href="/california-expungement-diy" className="hover:text-white transition-colors">California Guide</Link></li>
+              <li><Link href="/los-angeles" className="hover:text-white transition-colors">Los Angeles</Link></li>
+              <li><Link href="/orange-county" className="hover:text-white transition-colors">Orange County</Link></li>
+            </ul>
+          </div>
+
+          {/* Company / Legal */}
+          <div>
+            <h3 className="font-semibold text-white mb-4 text-sm uppercase tracking-wider">
+              Company
+            </h3>
+            <ul className="space-y-2 text-sm">
+              <li><Link href="/about" className="hover:text-white transition-colors">About Us</Link></li>
+              <li><Link href="/contact" className="hover:text-white transition-colors">Contact</Link></li>
+              <li><Link href="/privacy" className="hover:text-white transition-colors">Privacy Policy</Link></li>
+              <li><Link href="/terms" className="hover:text-white transition-colors">Terms of Service</Link></li>
+              <li><Link href="/disclaimer" className="hover:text-white transition-colors">Legal Disclaimer</Link></li>
+              <li><Link href="/unsubscribe" className="hover:text-white transition-colors">Unsubscribe</Link></li>
+            </ul>
+          </div>
+        </div>
+
+        {/* Attorney credentials bar */}
+        <div className="mt-12 pt-8 border-t border-slate-800">
+          <div className="bg-slate-800/50 rounded-lg p-5 mb-8 text-sm">
+            <p className="text-slate-300 leading-relaxed">
+              <span className="font-semibold text-white">Attorney Advertisement.</span>{' '}
+              Legal services provided by The Berhe Law Firm, APC. Attorney Tamerat S. Berhe,
+              California State Bar No. 298992. The information on this site is for general
+              informational purposes only and does not constitute legal advice. No attorney-client
+              relationship is formed by your use of this website. Past results do not guarantee
+              future outcomes.
+            </p>
+          </div>
+
+          <div className="flex flex-col sm:flex-row items-center justify-between gap-4 text-xs text-slate-500">
+            <p>© {year} Wipe That Record. All rights reserved.</p>
+            <p>
+              Licensed in California · CA State Bar #298992 ·{' '}
+              <a
+                href="https://apps.calbar.ca.gov/attorney/Licensee/Detail/298992"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hover:text-white transition-colors underline"
+              >
+                Verify
+              </a>
+            </p>
+          </div>
+        </div>
+      </div>
+    </footer>
+  )
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,141 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import Link from 'next/link'
+import { motion, AnimatePresence } from 'framer-motion'
+
+const navLinks = [
+  { href: '/#plans', label: 'Pricing' },
+  { href: '/about', label: 'About' },
+  { href: '/california-expungement-diy', label: 'DIY Guide' },
+  { href: '/los-angeles', label: 'Los Angeles' },
+  { href: '/orange-county', label: 'Orange County' },
+  { href: '/contact', label: 'Contact' },
+]
+
+export function Header() {
+  const [scrolled, setScrolled] = useState(false)
+  const [mobileOpen, setMobileOpen] = useState(false)
+
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 8)
+    onScroll()
+    window.addEventListener('scroll', onScroll, { passive: true })
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [])
+
+  return (
+    <header
+      className={`sticky top-0 z-30 w-full transition-all duration-300 ${
+        scrolled
+          ? 'bg-white/90 dark:bg-slate-900/90 backdrop-blur shadow-sm border-b border-slate-200/60 dark:border-slate-700/60'
+          : 'bg-white dark:bg-slate-900 border-b border-transparent'
+      }`}
+    >
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex items-center justify-between h-16">
+          {/* Logo */}
+          <Link href="/" className="flex items-center gap-2 group" aria-label="Wipe That Record home">
+            <svg
+              width="36"
+              height="36"
+              viewBox="0 0 36 36"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              className="text-blue-600 dark:text-blue-400"
+              aria-hidden="true"
+            >
+              <rect x="2" y="2" width="32" height="32" rx="8" fill="currentColor" />
+              <path
+                d="M10 18.5L15.5 24L26 13"
+                stroke="white"
+                strokeWidth="3"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+            <div className="flex flex-col leading-tight">
+              <span className="font-bold text-slate-900 dark:text-white text-base">
+                Wipe That Record
+              </span>
+              <span className="text-[10px] uppercase tracking-wider text-slate-500 dark:text-slate-400 font-semibold">
+                California Expungement
+              </span>
+            </div>
+          </Link>
+
+          {/* Desktop nav */}
+          <nav className="hidden lg:flex items-center gap-7">
+            {navLinks.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className="text-sm font-medium text-slate-700 dark:text-slate-300 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+              >
+                {link.label}
+              </Link>
+            ))}
+          </nav>
+
+          {/* CTA + mobile toggle */}
+          <div className="flex items-center gap-3">
+            <Link
+              href="/#plans"
+              className="hidden sm:inline-flex items-center gap-1.5 bg-blue-600 hover:bg-blue-700 text-white text-sm font-semibold px-4 py-2 rounded-lg transition-colors shadow-sm"
+            >
+              Get Started
+            </Link>
+            <button
+              type="button"
+              className="lg:hidden inline-flex items-center justify-center p-2 rounded-md text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
+              aria-label="Toggle menu"
+              aria-expanded={mobileOpen}
+              onClick={() => setMobileOpen((v) => !v)}
+            >
+              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                {mobileOpen ? (
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                ) : (
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+                )}
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Mobile menu */}
+      <AnimatePresence>
+        {mobileOpen && (
+          <motion.div
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: 'auto' }}
+            exit={{ opacity: 0, height: 0 }}
+            transition={{ duration: 0.2 }}
+            className="lg:hidden border-t border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 overflow-hidden"
+          >
+            <div className="px-4 py-4 space-y-1">
+              {navLinks.map((link) => (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  onClick={() => setMobileOpen(false)}
+                  className="block px-3 py-2 rounded-md text-base font-medium text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
+                >
+                  {link.label}
+                </Link>
+              ))}
+              <Link
+                href="/#plans"
+                onClick={() => setMobileOpen(false)}
+                className="block w-full text-center bg-blue-600 hover:bg-blue-700 text-white font-semibold px-4 py-3 rounded-lg mt-2 transition-colors"
+              >
+                Get Started
+              </Link>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </header>
+  )
+}

--- a/src/components/LegalPage.tsx
+++ b/src/components/LegalPage.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+
+interface LegalPageProps {
+  title: string
+  updated: string
+  children: React.ReactNode
+}
+
+export function LegalPage({ title, updated, children }: LegalPageProps) {
+  return (
+    <main className="bg-white dark:bg-slate-900 min-h-screen">
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+        <header className="mb-10 pb-8 border-b border-slate-200 dark:border-slate-800">
+          <h1 className="text-3xl sm:text-4xl font-bold text-slate-900 dark:text-white mb-3">
+            {title}
+          </h1>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Last updated: {updated}
+          </p>
+        </header>
+
+        <article className="prose-legal text-slate-700 dark:text-slate-300 leading-relaxed space-y-6">
+          {children}
+        </article>
+      </div>
+
+      <style>{`
+        .prose-legal h2 {
+          font-size: 1.5rem;
+          font-weight: 700;
+          color: rgb(15 23 42);
+          margin-top: 2.5rem;
+          margin-bottom: 1rem;
+          line-height: 1.3;
+        }
+        .dark .prose-legal h2 { color: rgb(241 245 249); }
+        .prose-legal h3 {
+          font-size: 1.125rem;
+          font-weight: 600;
+          color: rgb(30 41 59);
+          margin-top: 1.5rem;
+          margin-bottom: 0.5rem;
+        }
+        .dark .prose-legal h3 { color: rgb(226 232 240); }
+        .prose-legal p { margin-bottom: 1rem; }
+        .prose-legal ul { list-style: disc; padding-left: 1.5rem; margin-bottom: 1rem; }
+        .prose-legal ul li { margin-bottom: 0.4rem; }
+        .prose-legal a { color: rgb(37 99 235); text-decoration: underline; }
+        .prose-legal a:hover { color: rgb(29 78 216); }
+        .prose-legal strong { color: rgb(15 23 42); font-weight: 600; }
+        .dark .prose-legal strong { color: rgb(241 245 249); }
+      `}</style>
+    </main>
+  )
+}


### PR DESCRIPTION
Closes the gaps surfaced in the recent site audit so wipethatrecord.com is ready to operate as a legal-services site.

## What's new

### Global navigation
- `src/components/Header.tsx` — sticky header with logo, nav links, mobile menu, scroll-aware styling
- `src/components/Footer.tsx` — firm contact info, attorney bar number, service/company link columns, attorney-advertising notice, [California State Bar verification link](https://apps.calbar.ca.gov/attorney/Licensee/Detail/298992)

### Legal pages (required for legal-services compliance)
- `/privacy` — CCPA/CPRA-compliant privacy policy
- `/terms` — Terms of service, money-back-guarantee terms, no-guarantee-of-outcome
- `/disclaimer` — Attorney advertising, no attorney-client relationship, DIY-is-not-representation

### Marketing pages
- `/about` — Attorney credentials, firm story, values, stats
- `/contact` — Contact form wired to existing `/api/lead` endpoint

### Fixes
- Gate **Google Analytics, GTM, Facebook Pixel, Clarity, Hotjar** behind `NEXT_PUBLIC_*` env vars. Placeholder IDs (`G-XXXXXXXXXX`, `GTM-XXXXXXXXX`, etc.) no longer fire broken network requests
- Use env var for Google site verification meta tag
- Fix `src/app/layout.tsx` — was importing non-existent `LocalBusinessSchema` and `GoogleAnalytics` components and breaking the build
- Install `@modelcontextprotocol/sdk` peer dep required by `@vercel/mcp-adapter`
- Promo banner is no longer `sticky top-0` (conflicted with the new sticky header)

## Env vars to set in Vercel (optional but recommended)

```
NEXT_PUBLIC_GA_ID=G-XXXXXXX            # real GA4 ID
NEXT_PUBLIC_GTM_ID=GTM-XXXXXXX
NEXT_PUBLIC_FB_PIXEL_ID=...
NEXT_PUBLIC_CLARITY_ID=...
NEXT_PUBLIC_HOTJAR_ID=...
NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION=...
```

If any of these are absent, the related script simply won't load. No more placeholder IDs in production.

## Verified
- `npm run build` compiles successfully (only fails on collect-page-data when MongoDB isn't reachable, which is expected for local builds without DB access)
- Type errors are pre-existing in unrelated admin-panel files; `next.config.ts` already sets `typescript.ignoreBuildErrors: true`