### PR TITLE
Phase 1: document automation for paid orders

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "node --test src/lib/documents/__tests__/",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",

--- a/payload.config.ts
+++ b/payload.config.ts
@@ -13,6 +13,7 @@ import Products from './src/collections/Products'
 import Orders from './src/collections/Orders'
 import Analytics from './src/collections/Analytics'
 import EmailSequences from './src/collections/EmailSequences'
+import DocumentPackages from './src/collections/DocumentPackages'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -65,6 +66,7 @@ export default buildConfig({
     Orders,
     Analytics,
     EmailSequences,
+    DocumentPackages,
   ],
   globals: [
     // Add global settings for site configuration

--- a/src/app/api/documents/[id]/approve/route.ts
+++ b/src/app/api/documents/[id]/approve/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getPayload } from 'payload';
+import config from '@payload-config';
+import { authorizeInternal } from '../../_auth';
+import { approvePackage } from '@/lib/documents/service';
+
+// POST /api/documents/[id]/approve — record human-review approval (internal/admin only).
+// Body: { actor: string, notes?: string }
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const unauthorized = authorizeInternal(request);
+  if (unauthorized) return unauthorized;
+
+  try {
+    const { id } = await params;
+    const body = await request.json().catch(() => ({}));
+    const actor = typeof body.actor === 'string' && body.actor.trim() ? body.actor.trim() : null;
+    if (!actor) {
+      return NextResponse.json({ error: 'actor is required' }, { status: 400 });
+    }
+
+    const payload = await getPayload({ config });
+    const result = await approvePackage(payload, { id, actor, notes: body.notes });
+    return NextResponse.json({ success: true, ...result });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Approval failed';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/src/app/api/documents/[id]/generate/route.ts
+++ b/src/app/api/documents/[id]/generate/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getPayload } from 'payload';
+import config from '@payload-config';
+import { authorizeInternal } from '../../_auth';
+import { generatePackage } from '@/lib/documents/service';
+
+// POST /api/documents/[id]/generate — generate (or regenerate) the PDF packet
+// (internal/admin only). Blocked for review-required templates until approved.
+// Body (optional): { actor?: string }
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const unauthorized = authorizeInternal(request);
+  if (unauthorized) return unauthorized;
+
+  try {
+    const { id } = await params;
+    const body = await request.json().catch(() => ({}));
+    const actor = typeof body.actor === 'string' ? body.actor : undefined;
+
+    const payload = await getPayload({ config });
+    const result = await generatePackage(payload, { id, actor });
+
+    if (result.blocked) {
+      return NextResponse.json(
+        { success: false, blocked: true, status: result.status, error: 'Human review required before generation' },
+        { status: 409 },
+      );
+    }
+    return NextResponse.json({ success: true, ...result });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Generation failed';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/src/app/api/documents/[id]/route.ts
+++ b/src/app/api/documents/[id]/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getPayload } from 'payload';
+import config from '@payload-config';
+import { authorizeInternal } from '../_auth';
+
+// GET /api/documents/[id] — fetch a single document package (internal/admin only).
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const unauthorized = authorizeInternal(request);
+  if (unauthorized) return unauthorized;
+
+  try {
+    const { id } = await params;
+    const payload = await getPayload({ config });
+    const doc = await payload.findByID({
+      collection: 'document-packages' as any,
+      id,
+      depth: 1,
+    });
+    return NextResponse.json({ success: true, doc });
+  } catch (error) {
+    return NextResponse.json({ error: 'Document package not found' }, { status: 404 });
+  }
+}

--- a/src/app/api/documents/_auth.ts
+++ b/src/app/api/documents/_auth.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+// Internal/admin auth for the document endpoints, mirroring the cron routes
+// (src/app/api/cron/*). Staff drive these via tooling that holds CRON_SECRET; humans
+// can also manage packages through the role-gated Payload admin UI. These endpoints
+// expose document status and can generate files, so they must never be public.
+export function authorizeInternal(request: NextRequest): NextResponse | null {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) {
+    return NextResponse.json(
+      { error: 'CRON_SECRET is not configured on the server' },
+      { status: 503 },
+    );
+  }
+  const authHeader = request.headers.get('authorization');
+  if (authHeader !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  return null;
+}

--- a/src/app/api/documents/route.ts
+++ b/src/app/api/documents/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getPayload } from 'payload';
+import config from '../../../../payload.config';
+import { authorizeInternal } from './_auth';
+
+// GET /api/documents — list document packages (internal/admin only).
+export async function GET(request: NextRequest) {
+  const unauthorized = authorizeInternal(request);
+  if (unauthorized) return unauthorized;
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const page = parseInt(searchParams.get('page') || '1');
+    const limit = parseInt(searchParams.get('limit') || '25');
+    const status = searchParams.get('status') || '';
+
+    const where: any = {};
+    if (status && status !== 'all') where.status = { equals: status };
+
+    const payload = await getPayload({ config });
+    const result = await payload.find({
+      collection: 'document-packages' as any,
+      where: Object.keys(where).length ? where : undefined,
+      page,
+      limit,
+      sort: '-createdAt',
+      depth: 0,
+    });
+
+    return NextResponse.json({ success: true, ...result });
+  } catch (error) {
+    console.error('[documents] list error');
+    return NextResponse.json({ error: 'Failed to list document packages' }, { status: 500 });
+  }
+}

--- a/src/app/api/webhook/route.ts
+++ b/src/app/api/webhook/route.ts
@@ -2,6 +2,32 @@ import { NextRequest, NextResponse } from 'next/server';
 import { stripe } from '@/lib/stripe';
 import payload from 'payload';
 
+// Creates a document package for a paid checkout session. Additive and idempotent:
+// dedups on the Stripe session id, so webhook retries never duplicate packages. Any
+// failure is swallowed so it can never 500 the webhook or block lead creation.
+async function createDocumentPackage(session: any, leadId: string | number) {
+  try {
+    const { createPackageForSession } = await import('@/lib/documents/service');
+    const { templateKeyForSession } = await import('@/lib/documents/registry.mjs');
+    await createPackageForSession(payload as any, {
+      sourceSessionId: session.id,
+      templateKey: templateKeyForSession({
+        type: session.metadata?.type,
+        upgradeType: session.metadata?.upgradeType,
+      }),
+      customerEmail: session.customer_details?.email,
+      linkedLeadId: leadId,
+    });
+  } catch (error) {
+    try {
+      const { safeLog } = await import('@/lib/documents/redact.mjs');
+      safeLog('webhook.package_failed', { sessionPresent: !!session?.id });
+    } catch {
+      // never let logging failures bubble up
+    }
+  }
+}
+
 export async function POST(req: NextRequest) {
   const sig  = req.headers.get('stripe-signature') as string;
   const body = await req.text();
@@ -23,7 +49,7 @@ export async function POST(req: NextRequest) {
     // Handle different payment types
     if (s.metadata.type === 'diy') {
       // Initial DIY payment with analytics data
-      await payload.create({
+      const lead = await payload.create({
         collection: 'leads',
         data: {
           email: s.customer_details.email,
@@ -65,14 +91,16 @@ export async function POST(req: NextRequest) {
       } catch (error) {
         console.error('❌ Failed to send purchase notification:', error);
       }
-      
+
+      await createDocumentPackage(s, lead.id);
+
       return NextResponse.json({ ok: true });
-      
+
     } else if (s.metadata.type === 'upgrade') {
       // Upgrade payment - create a new lead record for the upgrade
       const upgradeType = s.metadata.upgradeType;
-      
-      await payload.create({
+
+      const lead = await payload.create({
         collection: 'leads',
         data: {
           first: s.customer_details.name?.split(' ')[0] || 'Customer',
@@ -95,6 +123,9 @@ export async function POST(req: NextRequest) {
       });
       
       console.log(`🚀 ${upgradeType} upgrade: ${s.customer_details.email} - $${s.amount_total / 100}`);
+
+      await createDocumentPackage(s, lead.id);
+
       return NextResponse.json({ ok: true });
     }
 

--- a/src/collections/DocumentPackages.ts
+++ b/src/collections/DocumentPackages.ts
@@ -1,0 +1,136 @@
+import { CollectionConfig } from 'payload';
+
+// Tracks the lifecycle of a document package produced for a paid order/customer.
+//
+// PII policy: this collection deliberately does NOT copy sensitive case data
+// (case numbers, charges, convictions, DOB). Sensitive legal details live on the
+// related `orders.caseDetails` record, reachable via the `linkedOrder` relationship
+// under the admin access gate. Only an operational `customerEmail` is stored here.
+const DocumentPackages: CollectionConfig = {
+  slug: 'document-packages',
+  admin: {
+    useAsTitle: 'sourceSessionId',
+    defaultColumns: ['sourceSessionId', 'templateKey', 'status', 'customerEmail', 'createdAt'],
+    group: 'Documents',
+    description:
+      'Document packages generated for paid orders. Review-required packages must be approved before generation.',
+  },
+  access: {
+    read: ({ req }) => req.user?.role === 'admin' || req.user?.role === 'superadmin',
+    create: ({ req }) => req.user?.role === 'admin' || req.user?.role === 'superadmin',
+    update: ({ req }) => req.user?.role === 'admin' || req.user?.role === 'superadmin',
+    delete: ({ req }) => req.user?.role === 'superadmin',
+  },
+  fields: [
+    {
+      name: 'sourceSessionId',
+      type: 'text',
+      required: true,
+      unique: true,
+      index: true,
+      admin: {
+        readOnly: true,
+        description: 'Idempotency key — Stripe checkout session id, or order:<id> / manual:<id>.',
+      },
+    },
+    {
+      name: 'templateKey',
+      type: 'select',
+      required: true,
+      options: [
+        { label: 'DIY Kit', value: 'diy_kit' },
+        { label: 'Expert Review', value: 'expert_review' },
+        { label: 'Full Service', value: 'full_service' },
+      ],
+    },
+    {
+      name: 'status',
+      type: 'select',
+      required: true,
+      defaultValue: 'intake_needed',
+      admin: {
+        readOnly: true,
+        description: 'Driven by the document service; do not edit directly.',
+      },
+      options: [
+        { label: 'Intake Needed', value: 'intake_needed' },
+        { label: 'Ready for Review', value: 'ready_for_review' },
+        { label: 'Needs Manual Review', value: 'needs_manual_review' },
+        { label: 'Generated', value: 'generated' },
+        { label: 'Delivered', value: 'delivered' },
+        { label: 'Blocked', value: 'blocked' },
+      ],
+    },
+    {
+      name: 'customerEmail',
+      type: 'email',
+      admin: {
+        description: 'Operational lookup only. Never written to logs or analytics.',
+      },
+    },
+    {
+      name: 'linkedLead',
+      type: 'relationship',
+      relationTo: 'leads' as any,
+      admin: {
+        description: 'Lead record created at purchase (current webhook path).',
+      },
+    },
+    {
+      name: 'linkedOrder',
+      type: 'relationship',
+      relationTo: 'orders' as any,
+      admin: {
+        description: 'Order record, when the order-based path is used.',
+      },
+    },
+    {
+      name: 'review',
+      type: 'group',
+      admin: {
+        description: 'Human-review gate. Required before generating personalized legal packets.',
+      },
+      fields: [
+        { name: 'approved', type: 'checkbox', defaultValue: false },
+        { name: 'reviewedBy', type: 'text' },
+        { name: 'reviewedAt', type: 'date', admin: { date: { pickerAppearance: 'dayAndTime' } } },
+        { name: 'reviewNotes', type: 'textarea' },
+      ],
+    },
+    {
+      name: 'generatedFile',
+      type: 'upload',
+      relationTo: 'media',
+      admin: {
+        description: 'Generated PDF packet (admin-gated storage). No public download route exists yet.',
+      },
+    },
+    {
+      name: 'downloadToken',
+      type: 'text',
+      admin: {
+        readOnly: true,
+        description: 'Reserved for a future signed-download route. Not used in Phase 1.',
+      },
+    },
+    {
+      name: 'auditLog',
+      type: 'array',
+      admin: {
+        readOnly: true,
+        description: 'Status/action history. Must never contain PII.',
+      },
+      fields: [
+        { name: 'at', type: 'text' },
+        { name: 'action', type: 'text' },
+        { name: 'fromStatus', type: 'text' },
+        { name: 'toStatus', type: 'text' },
+        { name: 'actor', type: 'text' },
+        { name: 'detail', type: 'text' },
+      ],
+    },
+  ],
+  timestamps: true,
+};
+
+export default DocumentPackages;

--- a/src/lib/documents/README.md
+++ b/src/lib/documents/README.md
@@ -1,0 +1,126 @@
+# Document Automation (Phase 1)
+
+Turns a **paid order** into a tracked **document package** with a clear lifecycle,
+a branded PDF packet, a human-review gate, and PII-safe handling.
+
+> **Scope / safety:** Phase 1 does **not** generate official California court forms
+> (e.g. CR-180) and does **not** auto-email personalized legal filings. It produces a
+> branded, **non-personalized** informational cover sheet + checklist packet that
+> explicitly states an official form template and human review are required before any
+> filing. Personalized legal filings are a later phase (official templates + deterministic
+> data mapping + mandatory human review).
+
+## Modules (`src/lib/documents/`)
+
+| File | Purpose |
+|------|---------|
+| `status.mjs` | Status machine: allowed transitions, audit entries. |
+| `registry.mjs` | Template registry; maps products/sessions → template key; initial status. |
+| `disclaimers.mjs` | Mandatory legal disclaimers embedded in every packet. |
+| `pdf.mjs` | **Dependency-free** PDF generator (hand-written bytes; no puppeteer/pdfkit). |
+| `redact.mjs` | PII-safe logging (`safeLog`, `redactEmail`). |
+| `service-core.mjs` | Runtime orchestration (create/approve/generate), DB-injected. |
+| `service.ts` | Typed wrapper over `service-core.mjs`. |
+| `index.ts` / `types.ts` | Typed entry point + TypeScript types. |
+
+Pure logic lives in `.mjs` so it can be unit-tested with zero dependencies via
+`node --test` on Node 20 (which cannot import `.ts` directly). The `.ts` files are thin
+typed wrappers around the `.mjs` core — single source of truth, no duplication.
+
+## Lifecycle / status machine
+
+```
+intake_needed ─▶ ready_for_review ─▶ generated ─▶ delivered
+      │                  │                │            │
+      ├─▶ needs_manual_review ◀───────────┴────────────┘
+      └─▶ blocked
+```
+
+- **DIY kit** (`requiresHumanReview: false`) → created as `ready_for_review`; can generate immediately.
+- **Expert Review / Full Service** (`requiresHumanReview: true`) → created as `intake_needed`;
+  generation is **blocked** (→ `needs_manual_review`) until a reviewer approves
+  (→ `ready_for_review`), then it can generate.
+
+`generated` is reachable only from `ready_for_review`.
+
+## Collection
+
+`DocumentPackages` (slug `document-packages`), admin group **Documents**. Admin/superadmin
+read/update; superadmin delete. Stores only: `sourceSessionId` (unique idempotency key),
+`templateKey`, `status`, `customerEmail` (operational lookup), `linkedLead`/`linkedOrder`,
+`review` gate, `generatedFile` (media), `downloadToken` (reserved), and a non-PII `auditLog`.
+
+**PII policy:** sensitive case data (case numbers, charges, convictions, DOB) is **not**
+copied here — it stays on `orders.caseDetails`, reachable via `linkedOrder` under the admin
+gate. Logs use `safeLog`, which redacts sensitive keys. No analytics events carry PII.
+
+## Post-payment hook
+
+`src/app/api/webhook/route.ts` (Stripe `checkout.session.completed`) creates the lead as
+before, then calls `createPackageForSession(payload, { sourceSessionId: session.id, ... })`.
+This is **additive, idempotent** (dedups on the Stripe session id, so retries don't
+duplicate), and **error-swallowing** (a packaging failure can never 500 the webhook or
+block lead creation).
+
+## Internal/admin API
+
+All routes require `Authorization: Bearer ${CRON_SECRET}` (same pattern as `api/cron/*`).
+Staff can also manage packages through the role-gated Payload admin UI. No public endpoints.
+
+| Method & path | Action |
+|---------------|--------|
+| `GET /api/documents` | List packages (`?status=`, `?page=`, `?limit=`). |
+| `GET /api/documents/[id]` | Fetch one package. |
+| `POST /api/documents/[id]/approve` | Record human-review approval. Body: `{ "actor": "name", "notes"?: "..." }`. |
+| `POST /api/documents/[id]/generate` | Generate/regenerate the PDF. `409` if review required and not approved. |
+
+Example:
+
+```bash
+curl -X POST https://wipethatrecord.com/api/documents/<id>/generate \
+  -H "Authorization: Bearer $CRON_SECRET" -H "Content-Type: application/json" -d '{}'
+```
+
+## Staff workflow
+
+1. A paid checkout creates a package automatically (via the webhook).
+2. DIY packages are `ready_for_review`; call **generate** to produce the PDF.
+3. Review/Full-Service packages are `intake_needed`; a reviewer verifies the case, calls
+   **approve**, then **generate**.
+4. The generated PDF is stored as admin-gated Payload **media** (`generatedFile`).
+   There is **no public download route yet** — see "Delivery" below.
+
+## Delivery (current state)
+
+The generated PDF lives in Payload media, accessible only through the admin gate. The
+`downloadToken` field is reserved for a future **signed-download route** so customers can
+retrieve their packet without exposing media publicly. Phase 1 does **not** expose
+sensitive PDFs publicly and does not auto-email packets.
+
+## Environment variables
+
+No new **required** secrets. Uses existing infrastructure:
+
+- `CRON_SECRET` — gates the `/api/documents/*` routes (already used by `api/cron/*`).
+- `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET` — existing Stripe webhook.
+- `PAYLOAD_SECRET`, `DATABASE_URI` — existing Payload/Mongo.
+
+## Tests
+
+```bash
+npm test        # node --test, zero dependencies
+npm run typecheck
+```
+
+Covers status transitions, template selection, idempotency, review gating, PDF validity
+(`%PDF`/`%%EOF`/disclaimers), and PII redaction.
+
+## Future phases (official court forms)
+
+1. Add official Judicial Council form templates (e.g. CR-180) as fillable assets.
+2. Build a **deterministic** data mapping from verified `orders.caseDetails` → form fields.
+3. Keep the human-review gate mandatory before any personalized filing is delivered.
+4. Add a signed-download route backed by `downloadToken` (short-lived, single-use).
+5. Optionally render official forms by overlaying mapped data — replacing the Phase 1
+   informational packet for personalized filings only.
+```

--- a/src/lib/documents/__tests__/pdf.test.mjs
+++ b/src/lib/documents/__tests__/pdf.test.mjs
@@ -1,0 +1,44 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildPacketPdf, escapePdfText, wrapLines } from '../pdf.mjs';
+
+function toText(bytes) {
+  return Buffer.from(bytes).toString('latin1');
+}
+
+test('produces a non-empty valid PDF buffer', () => {
+  const bytes = buildPacketPdf({ templateKey: 'diy_kit', referenceCode: 'WTR-TEST-001' });
+  assert.ok(bytes instanceof Uint8Array);
+  assert.ok(bytes.length > 500);
+  const text = toText(bytes);
+  assert.ok(text.startsWith('%PDF-1.4'), 'starts with PDF header');
+  assert.ok(text.trimEnd().endsWith('%%EOF'), 'ends with EOF');
+  assert.ok(text.includes('xref'), 'has xref table');
+  assert.ok(text.includes('startxref'), 'has startxref');
+});
+
+test('includes mandatory disclaimers', () => {
+  const text = toText(buildPacketPdf({ templateKey: 'full_service' }));
+  assert.ok(text.includes('not legal advice'));
+  assert.ok(text.includes('does not guarantee') || text.includes('not guarantee'));
+});
+
+test('works for every template key', () => {
+  for (const key of ['diy_kit', 'expert_review', 'full_service']) {
+    const text = toText(buildPacketPdf({ templateKey: key }));
+    assert.ok(text.startsWith('%PDF-1.4'));
+    assert.ok(text.trimEnd().endsWith('%%EOF'));
+  }
+});
+
+test('escapePdfText escapes parens/backslash and strips non-ascii', () => {
+  assert.equal(escapePdfText('a(b)c\\d'), 'a\\(b\\)c\\\\d');
+  assert.equal(escapePdfText('café'), 'caf '); // accented char replaced with space
+});
+
+test('wrapLines never exceeds max width and never loses words', () => {
+  const input = 'word '.repeat(80).trim();
+  const lines = wrapLines(input, 40);
+  for (const line of lines) assert.ok(line.length <= 40);
+  assert.equal(lines.join(' ').split(/\s+/).length, 80);
+});

--- a/src/lib/documents/__tests__/redact.test.mjs
+++ b/src/lib/documents/__tests__/redact.test.mjs
@@ -1,0 +1,39 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { redactEmail, redactFields, safeLog } from '../redact.mjs';
+
+test('redactEmail masks local and domain but keeps tld', () => {
+  assert.equal(redactEmail('jane.doe@example.com'), 'j***@e***.com');
+  assert.equal(redactEmail('not-an-email'), '[redacted]');
+  assert.equal(redactEmail(undefined), '[redacted]');
+});
+
+test('redactFields strips sensitive keys, keeps safe ones', () => {
+  const out = redactFields({
+    email: 'a@b.com',
+    caseNumber: 'CR-123',
+    charges: ['x'],
+    status: 'generated',
+    templateKey: 'diy_kit',
+  });
+  assert.equal(out.email, '[redacted]');
+  assert.equal(out.caseNumber, '[redacted]');
+  assert.equal(out.charges, '[redacted]');
+  assert.equal(out.status, 'generated');
+  assert.equal(out.templateKey, 'diy_kit');
+});
+
+test('safeLog never prints raw sensitive values', () => {
+  const original = console.log;
+  const captured = [];
+  console.log = (...args) => captured.push(args);
+  try {
+    safeLog('package.created', { email: 'secret@user.com', status: 'ready_for_review' });
+  } finally {
+    console.log = original;
+  }
+  const flat = JSON.stringify(captured);
+  assert.ok(!flat.includes('secret@user.com'));
+  assert.ok(flat.includes('ready_for_review'));
+  assert.ok(flat.includes('[redacted]'));
+});

--- a/src/lib/documents/__tests__/registry.test.mjs
+++ b/src/lib/documents/__tests__/registry.test.mjs
@@ -1,0 +1,41 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  templateKeyForSession,
+  templateKeyForProduct,
+  getTemplate,
+  TEMPLATE_KEYS,
+} from '../registry.mjs';
+
+test('session metadata maps to the correct template key', () => {
+  assert.equal(templateKeyForSession({ type: 'diy' }), 'diy_kit');
+  assert.equal(templateKeyForSession({ type: 'upgrade', upgradeType: 'review' }), 'expert_review');
+  assert.equal(templateKeyForSession({ type: 'upgrade', upgradeType: 'full' }), 'full_service');
+  assert.equal(templateKeyForSession({}), 'diy_kit'); // safe default
+});
+
+test('product fields map to the correct template key', () => {
+  assert.equal(templateKeyForProduct({ serviceType: 'full_service' }), 'full_service');
+  assert.equal(templateKeyForProduct({ category: 'legal' }), 'full_service');
+  assert.equal(templateKeyForProduct({ category: 'review' }), 'expert_review');
+  assert.equal(templateKeyForProduct({ category: 'diy' }), 'diy_kit');
+});
+
+test('review-required flags match business rules', () => {
+  assert.equal(getTemplate('diy_kit').requiresHumanReview, false);
+  assert.equal(getTemplate('expert_review').requiresHumanReview, true);
+  assert.equal(getTemplate('full_service').requiresHumanReview, true);
+});
+
+test('every template requires official court forms and has a checklist', () => {
+  for (const key of TEMPLATE_KEYS) {
+    const tpl = getTemplate(key);
+    assert.equal(tpl.requiresOfficialCourtForms, true);
+    assert.ok(tpl.checklist.length > 0);
+    assert.ok(tpl.sections.length > 0);
+  }
+});
+
+test('unknown template key throws', () => {
+  assert.throws(() => getTemplate('nope'));
+});

--- a/src/lib/documents/__tests__/service.test.mjs
+++ b/src/lib/documents/__tests__/service.test.mjs
@@ -1,0 +1,103 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createPackageForSession,
+  approvePackage,
+  generatePackage,
+} from '../service-core.mjs';
+
+// Minimal in-memory fake of the Payload Local API used by the service core.
+function makeFakePayload() {
+  const store = new Map(); // collection -> array of docs
+  let seq = 0;
+  const get = (c) => {
+    if (!store.has(c)) store.set(c, []);
+    return store.get(c);
+  };
+  return {
+    _store: store,
+    createCalls: 0,
+    async find({ collection, where }) {
+      const docs = get(collection);
+      if (where?.sourceSessionId?.equals !== undefined) {
+        return {
+          docs: docs.filter((d) => d.sourceSessionId === where.sourceSessionId.equals),
+        };
+      }
+      return { docs };
+    },
+    async create({ collection, data }) {
+      this.createCalls += 1;
+      const doc = { id: ++seq, ...data };
+      get(collection).push(doc);
+      return doc;
+    },
+    async findByID({ collection, id }) {
+      return get(collection).find((d) => d.id === id);
+    },
+    async update({ collection, id, data }) {
+      const doc = get(collection).find((d) => d.id === id);
+      Object.assign(doc, data);
+      return doc;
+    },
+  };
+}
+
+test('createPackageForSession is idempotent on sourceSessionId', async () => {
+  const payload = makeFakePayload();
+  const args = { sourceSessionId: 'cs_test_123', templateKey: 'diy_kit', customerEmail: 'a@b.com' };
+
+  const first = await createPackageForSession(payload, args);
+  const second = await createPackageForSession(payload, args);
+
+  assert.equal(first.created, true);
+  assert.equal(second.created, false);
+  assert.equal(first.id, second.id);
+  assert.equal(payload.createCalls, 1); // create only happened once
+});
+
+test('DIY packet starts ready_for_review (no human-review gate)', async () => {
+  const payload = makeFakePayload();
+  const { id } = await createPackageForSession(payload, {
+    sourceSessionId: 'cs_diy',
+    templateKey: 'diy_kit',
+  });
+  const doc = await payload.findByID({ collection: 'document-packages', id });
+  assert.equal(doc.status, 'ready_for_review');
+});
+
+test('review-required packet starts intake_needed and blocks generation until approved', async () => {
+  const payload = makeFakePayload();
+  const { id } = await createPackageForSession(payload, {
+    sourceSessionId: 'cs_full',
+    templateKey: 'full_service',
+  });
+  let doc = await payload.findByID({ collection: 'document-packages', id });
+  assert.equal(doc.status, 'intake_needed');
+
+  // Generation is blocked before approval.
+  const blocked = await generatePackage(payload, { id });
+  assert.equal(blocked.blocked, true);
+  assert.equal(blocked.status, 'needs_manual_review');
+
+  // After approval, generation succeeds and produces a media file.
+  await approvePackage(payload, { id, actor: 'reviewer@firm.com', notes: 'looks good' });
+  doc = await payload.findByID({ collection: 'document-packages', id });
+  assert.equal(doc.status, 'ready_for_review');
+  assert.equal(doc.review.approved, true);
+
+  const generated = await generatePackage(payload, { id });
+  assert.equal(generated.status, 'generated');
+  doc = await payload.findByID({ collection: 'document-packages', id });
+  assert.ok(doc.generatedFile, 'generatedFile is set');
+});
+
+test('DIY packet generates immediately without approval', async () => {
+  const payload = makeFakePayload();
+  const { id } = await createPackageForSession(payload, {
+    sourceSessionId: 'cs_diy2',
+    templateKey: 'diy_kit',
+  });
+  const generated = await generatePackage(payload, { id });
+  assert.equal(generated.status, 'generated');
+});

--- a/src/lib/documents/__tests__/status.test.mjs
+++ b/src/lib/documents/__tests__/status.test.mjs
@@ -1,0 +1,51 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  canTransition,
+  assertTransition,
+  transition,
+  appendAudit,
+  InvalidTransitionError,
+} from '../status.mjs';
+
+test('allowed transitions return true', () => {
+  assert.equal(canTransition('intake_needed', 'ready_for_review'), true);
+  assert.equal(canTransition('ready_for_review', 'generated'), true);
+  assert.equal(canTransition('generated', 'delivered'), true);
+});
+
+test('generated is reachable only from ready_for_review', () => {
+  assert.equal(canTransition('intake_needed', 'generated'), false);
+  assert.equal(canTransition('needs_manual_review', 'generated'), false);
+  assert.equal(canTransition('ready_for_review', 'generated'), true);
+});
+
+test('same-status transition is idempotent-allowed', () => {
+  assert.equal(canTransition('generated', 'generated'), true);
+});
+
+test('invalid transition throws InvalidTransitionError', () => {
+  assert.throws(() => assertTransition('delivered', 'generated'), InvalidTransitionError);
+});
+
+test('transition returns new status and audit entry', () => {
+  const { status, entry } = transition({
+    from: 'intake_needed',
+    to: 'ready_for_review',
+    actor: 'tester',
+    detail: 'ok',
+  });
+  assert.equal(status, 'ready_for_review');
+  assert.equal(entry.fromStatus, 'intake_needed');
+  assert.equal(entry.toStatus, 'ready_for_review');
+  assert.equal(entry.actor, 'tester');
+  assert.ok(entry.at);
+});
+
+test('appendAudit returns a new array with the entry', () => {
+  const log = appendAudit([], { action: 'created' });
+  assert.equal(log.length, 1);
+  const log2 = appendAudit(log, { action: 'status_change' });
+  assert.equal(log2.length, 2);
+  assert.equal(log.length, 1); // original not mutated
+});

--- a/src/lib/documents/disclaimers.mjs
+++ b/src/lib/documents/disclaimers.mjs
@@ -1,0 +1,11 @@
+// Mandatory disclaimers included on every generated packet and in customer-facing
+// document emails. These keep the automation from implying guaranteed outcomes or
+// an attorney-client relationship, and make clear that personalized legal filings
+// require official court form templates plus human review before delivery.
+
+export const DISCLAIMERS = [
+  'This document is an informational packet only. It is not legal advice and does not create an attorney-client relationship.',
+  'WipeThatRecord does not guarantee that any record will be expunged, dismissed, sealed, or otherwise changed. Eligibility and outcomes are determined solely by the court.',
+  'Any personalized court filing must use the official California Judicial Council form for your case type and must be reviewed by qualified staff before it is filed.',
+  'Always verify current forms, fees, and procedures with the court in the county where your case was handled before filing anything.',
+];

--- a/src/lib/documents/index.ts
+++ b/src/lib/documents/index.ts
@@ -1,0 +1,70 @@
+// Typed entry point for the document-automation modules. The pure logic lives in
+// sibling .mjs files (so it can be unit-tested with zero-dependency `node --test`
+// on Node 20, which cannot import .ts directly). This shim adds TypeScript types.
+
+import type {
+  AuditEntry,
+  DocumentStatus,
+  PacketInput,
+  TemplateDefinition,
+  TemplateKey,
+} from './types';
+
+// The .mjs modules carry no type declarations; treat them as untyped at this boundary
+// and expose typed wrappers below as the public surface.
+import * as statusImplTyped from './status.mjs';
+import * as registryImplTyped from './registry.mjs';
+import * as pdfImplTyped from './pdf.mjs';
+import * as redactImplTyped from './redact.mjs';
+import { DISCLAIMERS as DISCLAIMERS_IMPL } from './disclaimers.mjs';
+
+const statusImpl = statusImplTyped as any;
+const registryImpl = registryImplTyped as any;
+const pdfImpl = pdfImplTyped as any;
+const redactImpl = redactImplTyped as any;
+
+export const STATUSES = statusImpl.STATUSES as DocumentStatus[];
+export const TRANSITIONS = statusImpl.TRANSITIONS as Record<DocumentStatus, DocumentStatus[]>;
+export const InvalidTransitionError = statusImpl.InvalidTransitionError as typeof Error;
+
+export const canTransition = (from: DocumentStatus, to: DocumentStatus): boolean =>
+  statusImpl.canTransition(from, to);
+export const assertTransition = (from: DocumentStatus, to: DocumentStatus): void =>
+  statusImpl.assertTransition(from, to);
+export const transition = (args: {
+  from: DocumentStatus;
+  to: DocumentStatus;
+  actor?: string;
+  detail?: string;
+}): { status: DocumentStatus; entry: AuditEntry } => statusImpl.transition(args);
+export const appendAudit = (log: AuditEntry[] | undefined, entry: AuditEntry): AuditEntry[] =>
+  statusImpl.appendAudit(log, entry);
+export const buildAuditEntry = (args: {
+  action: string;
+  fromStatus?: DocumentStatus | null;
+  toStatus?: DocumentStatus | null;
+  actor?: string;
+  detail?: string;
+}): AuditEntry => statusImpl.buildAuditEntry(args);
+
+export const TEMPLATE_KEYS = registryImpl.TEMPLATE_KEYS as TemplateKey[];
+export const TEMPLATES = registryImpl.TEMPLATES as Record<TemplateKey, TemplateDefinition>;
+export const getTemplate = (key: TemplateKey): TemplateDefinition => registryImpl.getTemplate(key);
+export const templateKeyForSession = (args: {
+  type?: string;
+  upgradeType?: string;
+}): TemplateKey => registryImpl.templateKeyForSession(args);
+export const templateKeyForProduct = (args: {
+  category?: string;
+  serviceType?: string;
+}): TemplateKey => registryImpl.templateKeyForProduct(args);
+
+export const buildPacketPdf = (input: PacketInput): Uint8Array => pdfImpl.buildPacketPdf(input);
+
+export const redactEmail = (email?: string): string => redactImpl.redactEmail(email);
+export const safeLog = (scope: string, fields?: Record<string, unknown>): void =>
+  redactImpl.safeLog(scope, fields);
+
+export const DISCLAIMERS = DISCLAIMERS_IMPL as string[];
+
+export type { AuditEntry, DocumentStatus, PacketInput, TemplateDefinition, TemplateKey };

--- a/src/lib/documents/pdf.mjs
+++ b/src/lib/documents/pdf.mjs
@@ -1,0 +1,171 @@
+// Dependency-free PDF generator.
+//
+// We hand-emit a minimal but valid PDF (PDF 1.4, Helvetica base-14 font, no embedded
+// fonts) so the build has ZERO native/runtime dependencies. Heavy generators
+// (puppeteer/pdfkit) risk breaking the Vercel build, so they are intentionally avoided.
+// This produces a branded cover sheet + checklist packet from NON-SENSITIVE data and
+// is structured to be swapped for official-form rendering in a later phase.
+
+import { getTemplate } from './registry.mjs';
+import { DISCLAIMERS } from './disclaimers.mjs';
+
+const PAGE_WIDTH = 612; // US Letter @ 72dpi
+const PAGE_HEIGHT = 792;
+const MARGIN = 56;
+const LINE_HEIGHT = 16;
+const MAX_CHARS_PER_LINE = 92; // conservative for Helvetica 11pt within margins
+const LINES_PER_PAGE = Math.floor((PAGE_HEIGHT - MARGIN * 2) / LINE_HEIGHT) - 1;
+
+// Escape text for a PDF literal string and drop anything outside printable ASCII
+// (we only use the standard Helvetica WinAnsi range).
+export function escapePdfText(text) {
+  return String(text)
+    .replace(/[^\x20-\x7E]/g, ' ')
+    .replace(/\\/g, '\\\\')
+    .replace(/\(/g, '\\(')
+    .replace(/\)/g, '\\)');
+}
+
+// Greedy word-wrap to a max character width.
+export function wrapLines(text, maxChars = MAX_CHARS_PER_LINE) {
+  const words = String(text).split(/\s+/).filter(Boolean);
+  const lines = [];
+  let current = '';
+  for (const word of words) {
+    if (!current.length) {
+      current = word;
+    } else if (current.length + 1 + word.length <= maxChars) {
+      current += ' ' + word;
+    } else {
+      lines.push(current);
+      current = word;
+    }
+  }
+  if (current.length) lines.push(current);
+  return lines.length ? lines : [''];
+}
+
+// Build the flat list of styled lines for the whole document.
+function buildStyledLines(template, { recipientLabel, referenceCode, generatedAt }) {
+  const lines = [];
+  const push = (text, size = 11) => lines.push({ text, size });
+
+  push(template.title, 18);
+  push('WipeThatRecord — California Record Relief', 11);
+  push('', 11);
+  if (recipientLabel) push(`Prepared for: ${recipientLabel}`, 11);
+  if (referenceCode) push(`Reference: ${referenceCode}`, 11);
+  push(`Generated: ${generatedAt || new Date().toISOString().slice(0, 10)}`, 11);
+  push('', 11);
+
+  for (const section of template.sections) {
+    push(section.heading, 13);
+    for (const paragraph of section.body) {
+      for (const wrapped of wrapLines(paragraph)) push(wrapped, 11);
+    }
+    push('', 11);
+  }
+
+  push('Checklist', 13);
+  for (const item of template.checklist) {
+    const wrapped = wrapLines(`[ ] ${item}`);
+    wrapped.forEach((w) => push(w, 11));
+  }
+  push('', 11);
+
+  push('Important disclaimers', 13);
+  for (const disclaimer of DISCLAIMERS) {
+    for (const wrapped of wrapLines(disclaimer)) push(wrapped, 10);
+  }
+
+  return lines;
+}
+
+function paginate(lines) {
+  const pages = [];
+  for (let i = 0; i < lines.length; i += LINES_PER_PAGE) {
+    pages.push(lines.slice(i, i + LINES_PER_PAGE));
+  }
+  return pages.length ? pages : [[{ text: '', size: 11 }]];
+}
+
+function buildContentStream(pageLines) {
+  let stream = 'BT\n';
+  stream += `1 0 0 1 ${MARGIN} ${PAGE_HEIGHT - MARGIN} Tm\n`;
+  stream += `${LINE_HEIGHT} TL\n`;
+  let currentSize = 0;
+  for (const line of pageLines) {
+    if (line.size !== currentSize) {
+      stream += `/F1 ${line.size} Tf\n`;
+      currentSize = line.size;
+    }
+    stream += `(${escapePdfText(line.text)}) Tj\n`;
+    stream += 'T*\n';
+  }
+  stream += 'ET';
+  return stream;
+}
+
+// Assemble the PDF objects with a correct cross-reference table.
+export function buildPacketPdf(input = {}) {
+  const { templateKey, recipientLabel, referenceCode, generatedAt } = input;
+  const template = getTemplate(templateKey);
+
+  const styledLines = buildStyledLines(template, { recipientLabel, referenceCode, generatedAt });
+  const pages = paginate(styledLines);
+
+  // Object layout:
+  // 1: Catalog, 2: Pages, 3: Font.
+  // Then for each page: a Page object and a Contents stream object.
+  const fontObjNum = 3;
+  const pagesObjNum = 2;
+  const firstPageObj = 4;
+
+  const pageObjNums = [];
+  const contentObjNums = [];
+  for (let i = 0; i < pages.length; i++) {
+    pageObjNums.push(firstPageObj + i * 2);
+    contentObjNums.push(firstPageObj + i * 2 + 1);
+  }
+
+  const objects = [];
+  objects[1] = `<< /Type /Catalog /Pages ${pagesObjNum} 0 R >>`;
+  objects[pagesObjNum] =
+    `<< /Type /Pages /Kids [${pageObjNums.map((n) => `${n} 0 R`).join(' ')}] /Count ${pages.length} >>`;
+  objects[fontObjNum] =
+    '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>';
+
+  pages.forEach((pageLines, idx) => {
+    const pageObj = pageObjNums[idx];
+    const contentObj = contentObjNums[idx];
+    objects[pageObj] =
+      `<< /Type /Page /Parent ${pagesObjNum} 0 R ` +
+      `/MediaBox [0 0 ${PAGE_WIDTH} ${PAGE_HEIGHT}] ` +
+      `/Resources << /Font << /F1 ${fontObjNum} 0 R >> >> ` +
+      `/Contents ${contentObj} 0 R >>`;
+
+    const content = buildContentStream(pageLines);
+    objects[contentObj] =
+      `<< /Length ${Buffer.byteLength(content, 'latin1')} >>\nstream\n${content}\nendstream`;
+  });
+
+  // Serialize with byte-offset tracking for the xref table.
+  const totalObjects = objects.length - 1; // index 0 unused
+  let pdf = '%PDF-1.4\n';
+  const offsets = [];
+  for (let n = 1; n <= totalObjects; n++) {
+    offsets[n] = Buffer.byteLength(pdf, 'latin1');
+    pdf += `${n} 0 obj\n${objects[n]}\nendobj\n`;
+  }
+
+  const xrefOffset = Buffer.byteLength(pdf, 'latin1');
+  pdf += `xref\n0 ${totalObjects + 1}\n`;
+  pdf += '0000000000 65535 f \n';
+  for (let n = 1; n <= totalObjects; n++) {
+    pdf += `${String(offsets[n]).padStart(10, '0')} 00000 n \n`;
+  }
+  pdf += `trailer\n<< /Size ${totalObjects + 1} /Root 1 0 R >>\n`;
+  pdf += `startxref\n${xrefOffset}\n%%EOF`;
+
+  return new Uint8Array(Buffer.from(pdf, 'latin1'));
+}

--- a/src/lib/documents/redact.mjs
+++ b/src/lib/documents/redact.mjs
@@ -1,0 +1,60 @@
+// PII-safe logging helpers. Sensitive client / criminal-record data must never reach
+// application logs or analytics events. Use safeLog instead of console.log when any
+// field could carry PII.
+
+export const SENSITIVE_KEYS = [
+  'email',
+  'phone',
+  'dob',
+  'dateofbirth',
+  'ssn',
+  'casenumber',
+  'case_number',
+  'charges',
+  'charge',
+  'conviction',
+  'convictiontype',
+  'first',
+  'last',
+  'firstname',
+  'lastname',
+  'name',
+  'fullname',
+  'street',
+  'address',
+];
+
+// a***@e***.com  — keeps enough to correlate without exposing the address.
+export function redactEmail(email) {
+  if (typeof email !== 'string' || !email.includes('@')) return '[redacted]';
+  const [local, domain] = email.split('@');
+  const dotIdx = domain.lastIndexOf('.');
+  const tld = dotIdx >= 0 ? domain.slice(dotIdx) : '';
+  const domainName = dotIdx >= 0 ? domain.slice(0, dotIdx) : domain;
+  const mask = (s) => (s.length ? `${s[0]}***` : '***');
+  return `${mask(local)}@${mask(domainName)}${tld}`;
+}
+
+function isSensitiveKey(key) {
+  return SENSITIVE_KEYS.includes(String(key).toLowerCase());
+}
+
+// Returns a shallow copy of `fields` with sensitive values replaced by '[redacted]'.
+export function redactFields(fields) {
+  if (!fields || typeof fields !== 'object') return fields;
+  const out = {};
+  for (const [k, v] of Object.entries(fields)) {
+    out[k] = isSensitiveKey(k) ? '[redacted]' : v;
+  }
+  return out;
+}
+
+// Structured, PII-safe console log. `scope` is a short event name; `fields` are
+// non-sensitive identifiers/flags (sensitive keys are auto-redacted as a safety net).
+export function safeLog(scope, fields) {
+  if (fields === undefined) {
+    console.log(`[documents] ${scope}`);
+    return;
+  }
+  console.log(`[documents] ${scope}`, redactFields(fields));
+}

--- a/src/lib/documents/registry.mjs
+++ b/src/lib/documents/registry.mjs
@@ -1,0 +1,145 @@
+// Template registry mapping paid products to document-package templates.
+//
+// IMPORTANT: Sections contain only generic, non-personalized guidance and checklist
+// items. They deliberately contain NO official court-form field content (e.g. CR-180).
+// Official forms + deterministic data mapping + human review are a later phase.
+
+export const TEMPLATE_KEYS = ['diy_kit', 'expert_review', 'full_service'];
+
+export const TEMPLATES = {
+  diy_kit: {
+    key: 'diy_kit',
+    title: 'California Record Relief — DIY Starter Packet',
+    productLabel: 'DIY Kit',
+    // DIY packet is informational only, so it does not require a human review gate
+    // before the (non-personalized) starter packet is produced. The official court
+    // form itself still must be obtained and reviewed by the customer/staff.
+    requiresHumanReview: false,
+    requiresOfficialCourtForms: true,
+    sections: [
+      {
+        heading: 'What this packet is',
+        body: [
+          'A step-by-step starter guide for pursuing California record relief on your own.',
+          'It explains the general process and what to gather. It does not contain a completed court form.',
+        ],
+      },
+      {
+        heading: 'How the process generally works',
+        body: [
+          '1. Confirm your eligibility for the relief you are seeking.',
+          '2. Obtain the correct official Judicial Council form for your case type from the court.',
+          '3. Complete the form accurately using your own case records.',
+          '4. File with the correct court and pay or request a waiver of any fees.',
+          '5. Track your hearing date and the court’s decision.',
+        ],
+      },
+    ],
+    checklist: [
+      'Locate your case number and the county/court where the case was handled',
+      'Obtain a copy of your record of conviction (RAP sheet or court docket)',
+      'Confirm any probation is complete and fines/restitution are paid',
+      'Download the correct official Judicial Council form for your case type',
+      'Complete the form using your own accurate case information',
+      'Have the completed form reviewed before filing',
+      'File with the court and keep proof of filing',
+    ],
+  },
+
+  expert_review: {
+    key: 'expert_review',
+    title: 'California Record Relief — Expert Review Packet',
+    productLabel: 'Expert Review',
+    // Personalized review of a customer's situation: must be approved by qualified
+    // staff (human-review gate) before any packet is generated or delivered.
+    requiresHumanReview: true,
+    requiresOfficialCourtForms: true,
+    sections: [
+      {
+        heading: 'What this packet is',
+        body: [
+          'A cover sheet for the expert review of your record-relief documents.',
+          'A qualified reviewer must approve your case before any personalized packet is produced.',
+        ],
+      },
+      {
+        heading: 'Review checklist (staff)',
+        body: [
+          'Verify eligibility against the records provided.',
+          'Confirm the correct official form and county are identified.',
+          'Flag anything that requires manual handling before delivery.',
+        ],
+      },
+    ],
+    checklist: [
+      'Records received and verified',
+      'Eligibility assessed',
+      'Correct official form identified',
+      'Reviewer approval recorded',
+    ],
+  },
+
+  full_service: {
+    key: 'full_service',
+    title: 'California Record Relief — Full Service Packet',
+    productLabel: 'Full Service',
+    requiresHumanReview: true,
+    requiresOfficialCourtForms: true,
+    sections: [
+      {
+        heading: 'What this packet is',
+        body: [
+          'A case cover sheet for full-service handling of your record-relief matter.',
+          'A qualified team member must approve your case before any personalized filing packet is produced.',
+        ],
+      },
+      {
+        heading: 'Case handling checklist (staff)',
+        body: [
+          'Confirm scope and county.',
+          'Gather and verify all required records.',
+          'Prepare the official form using verified data.',
+          'Obtain human review approval before filing.',
+        ],
+      },
+    ],
+    checklist: [
+      'Intake complete',
+      'Records verified',
+      'Official form prepared from verified data',
+      'Human review approval recorded',
+      'Filing scheduled',
+    ],
+  },
+};
+
+export function getTemplate(key) {
+  const tpl = TEMPLATES[key];
+  if (!tpl) throw new Error(`Unknown template key: ${key}`);
+  return tpl;
+}
+
+// Maps the Stripe checkout session metadata (see src/app/api/webhook/route.ts) to a
+// template key. Mirrors the webhook's metadata.type / upgradeType branches.
+export function templateKeyForSession({ type, upgradeType } = {}) {
+  if (type === 'diy') return 'diy_kit';
+  if (type === 'upgrade') {
+    if (upgradeType === 'review') return 'expert_review';
+    if (upgradeType === 'full') return 'full_service';
+  }
+  return 'diy_kit';
+}
+
+// Initial status for a newly created package: packets that require human review start
+// in intake_needed (gated); informational packets are immediately ready_for_review.
+export function initialStatusForTemplate(key) {
+  return getTemplate(key).requiresHumanReview ? 'intake_needed' : 'ready_for_review';
+}
+
+// Maps a Products collection record (category / serviceType) to a template key.
+// Used by the future order-based path.
+export function templateKeyForProduct({ category, serviceType } = {}) {
+  if (serviceType === 'full_service' || category === 'legal') return 'full_service';
+  if (category === 'review') return 'expert_review';
+  return 'diy_kit';
+}

--- a/src/lib/documents/service-core.mjs
+++ b/src/lib/documents/service-core.mjs
@@ -1,0 +1,163 @@
+// Runtime core for document-package orchestration, kept in .mjs so it can be unit
+// tested with zero-dependency `node --test` on Node 20. service.ts is a thin typed
+// wrapper around these functions.
+
+import { getTemplate, initialStatusForTemplate } from './registry.mjs';
+import { buildAuditEntry, transition } from './status.mjs';
+import { buildPacketPdf } from './pdf.mjs';
+import { safeLog } from './redact.mjs';
+
+const COLLECTION = 'document-packages';
+
+async function findBySession(payload, sourceSessionId) {
+  const res = await payload.find({
+    collection: COLLECTION,
+    where: { sourceSessionId: { equals: sourceSessionId } },
+    limit: 1,
+  });
+  return res.docs[0];
+}
+
+// Idempotent: safe to call repeatedly for the same session (Stripe webhook retries).
+export async function createPackageForSession(payload, args) {
+  const { sourceSessionId, templateKey, customerEmail, linkedLeadId, linkedOrderId } = args;
+
+  const existing = await findBySession(payload, sourceSessionId);
+  if (existing) {
+    safeLog('package.exists', { templateKey, sessionPresent: true });
+    return { created: false, id: existing.id };
+  }
+
+  const template = getTemplate(templateKey);
+  const initialStatus = initialStatusForTemplate(templateKey);
+
+  try {
+    const doc = await payload.create({
+      collection: COLLECTION,
+      data: {
+        sourceSessionId,
+        templateKey,
+        customerEmail,
+        status: initialStatus,
+        ...(linkedLeadId ? { linkedLead: linkedLeadId } : {}),
+        ...(linkedOrderId ? { linkedOrder: linkedOrderId } : {}),
+        review: { approved: false },
+        auditLog: [
+          buildAuditEntry({
+            action: 'created',
+            toStatus: initialStatus,
+            actor: 'system',
+            detail: `Created from paid ${template.productLabel} purchase`,
+          }),
+        ],
+      },
+    });
+    safeLog('package.created', { templateKey, status: initialStatus });
+    return { created: true, id: doc.id };
+  } catch (err) {
+    // Unique-index race (concurrent retries): re-query and treat as existing.
+    const race = await findBySession(payload, sourceSessionId);
+    if (race) return { created: false, id: race.id };
+    throw err;
+  }
+}
+
+export async function createDocumentPackageForOrder(payload, args) {
+  return createPackageForSession(payload, {
+    sourceSessionId: `order:${args.orderId}`,
+    templateKey: args.templateKey,
+    customerEmail: args.customerEmail,
+    linkedOrderId: args.orderId,
+  });
+}
+
+async function loadPackage(payload, id) {
+  const doc = await payload.findByID({ collection: COLLECTION, id });
+  if (!doc) throw new Error('Document package not found');
+  return doc;
+}
+
+export async function approvePackage(payload, args) {
+  const pkg = await loadPackage(payload, args.id);
+  const { status, entry } = transition({
+    from: pkg.status,
+    to: 'ready_for_review',
+    actor: args.actor,
+    detail: 'Human review approved',
+  });
+  await payload.update({
+    collection: COLLECTION,
+    id: args.id,
+    data: {
+      status,
+      review: {
+        approved: true,
+        reviewedBy: args.actor,
+        reviewedAt: new Date().toISOString(),
+        reviewNotes: args.notes,
+      },
+      auditLog: [...(pkg.auditLog || []), entry],
+    },
+  });
+  safeLog('package.approved', { id: String(args.id) });
+  return { status };
+}
+
+// Generates the PDF packet and stores it in Payload media. Blocked unless a
+// review-required template has been approved.
+export async function generatePackage(payload, args) {
+  const pkg = await loadPackage(payload, args.id);
+  const template = getTemplate(pkg.templateKey);
+
+  if (template.requiresHumanReview && !(pkg.review && pkg.review.approved)) {
+    const { status, entry } = transition({
+      from: pkg.status,
+      to: 'needs_manual_review',
+      actor: args.actor || 'system',
+      detail: 'Generation blocked: human review required before delivery',
+    });
+    await payload.update({
+      collection: COLLECTION,
+      id: args.id,
+      data: { status, auditLog: [...(pkg.auditLog || []), entry] },
+    });
+    safeLog('package.generate_blocked', { id: String(args.id) });
+    return { status, blocked: true };
+  }
+
+  const pdf = buildPacketPdf({
+    templateKey: pkg.templateKey,
+    referenceCode: pkg.sourceSessionId,
+    generatedAt: new Date().toISOString().slice(0, 10),
+  });
+
+  const media = await payload.create({
+    collection: 'media',
+    data: { alt: `${template.productLabel} packet` },
+    file: {
+      data: Buffer.from(pdf),
+      mimetype: 'application/pdf',
+      name: `packet-${pkg.sourceSessionId}.pdf`.replace(/[^a-zA-Z0-9.-]/g, '_'),
+      size: pdf.byteLength,
+    },
+  });
+
+  const { status, entry } = transition({
+    from: pkg.status,
+    to: 'generated',
+    actor: args.actor || 'system',
+    detail: 'Packet generated',
+  });
+
+  await payload.update({
+    collection: COLLECTION,
+    id: args.id,
+    data: {
+      status,
+      generatedFile: media.id,
+      auditLog: [...(pkg.auditLog || []), entry],
+    },
+  });
+  safeLog('package.generated', { id: String(args.id), templateKey: pkg.templateKey });
+  return { status };
+}

--- a/src/lib/documents/service.ts
+++ b/src/lib/documents/service.ts
@@ -1,0 +1,45 @@
+// Typed wrapper over the runtime core (service-core.mjs). The core is .mjs so it can
+// be unit-tested with zero-dependency `node --test` on Node 20 (which cannot import
+// .ts directly). All persistence goes through the injected Payload Local API client.
+
+import type { Payload } from 'payload';
+import * as coreTyped from './service-core.mjs';
+import type { DocumentStatus, TemplateKey } from './types';
+
+const core = coreTyped as any;
+
+interface CreateForSessionArgs {
+  sourceSessionId: string;
+  templateKey: TemplateKey;
+  customerEmail?: string;
+  linkedLeadId?: string | number;
+  linkedOrderId?: string | number;
+}
+
+export function createPackageForSession(
+  payload: Payload,
+  args: CreateForSessionArgs,
+): Promise<{ created: boolean; id: string | number }> {
+  return core.createPackageForSession(payload, args);
+}
+
+export function createDocumentPackageForOrder(
+  payload: Payload,
+  args: { orderId: string | number; templateKey: TemplateKey; customerEmail?: string },
+): Promise<{ created: boolean; id: string | number }> {
+  return core.createDocumentPackageForOrder(payload, args);
+}
+
+export function approvePackage(
+  payload: Payload,
+  args: { id: string | number; actor: string; notes?: string },
+): Promise<{ status: DocumentStatus }> {
+  return core.approvePackage(payload, args);
+}
+
+export function generatePackage(
+  payload: Payload,
+  args: { id: string | number; actor?: string },
+): Promise<{ status: DocumentStatus; blocked?: boolean }> {
+  return core.generatePackage(payload, args);
+}

--- a/src/lib/documents/status.mjs
+++ b/src/lib/documents/status.mjs
@@ -1,0 +1,75 @@
+// Document-package status machine. Pure functions only — no database access — so it
+// can be unit-tested with zero dependencies and reused by the service layer.
+
+export const STATUSES = [
+  'intake_needed',
+  'ready_for_review',
+  'needs_manual_review',
+  'generated',
+  'delivered',
+  'blocked',
+];
+
+// Allowed transitions: from -> [to...]. `generated` is reachable only from
+// `ready_for_review`, which (for review-required templates) the service layer only
+// permits after a human approval is recorded.
+export const TRANSITIONS = {
+  intake_needed: ['ready_for_review', 'needs_manual_review', 'blocked'],
+  ready_for_review: ['generated', 'needs_manual_review', 'blocked'],
+  needs_manual_review: ['ready_for_review', 'blocked'],
+  generated: ['delivered', 'needs_manual_review', 'blocked'],
+  delivered: ['needs_manual_review', 'blocked'],
+  blocked: ['intake_needed', 'needs_manual_review'],
+};
+
+export class InvalidTransitionError extends Error {
+  constructor(from, to) {
+    super(`Invalid document-package status transition: ${from} -> ${to}`);
+    this.name = 'InvalidTransitionError';
+    this.from = from;
+    this.to = to;
+  }
+}
+
+export function canTransition(from, to) {
+  if (from === to) return true; // idempotent re-set is allowed (e.g. regenerate)
+  const allowed = TRANSITIONS[from];
+  return Array.isArray(allowed) && allowed.includes(to);
+}
+
+export function assertTransition(from, to) {
+  if (!canTransition(from, to)) throw new InvalidTransitionError(from, to);
+}
+
+// Builds an audit entry. `detail` must never contain PII — callers pass short,
+// non-sensitive descriptions only.
+export function buildAuditEntry({ action, fromStatus, toStatus, actor, detail }) {
+  return {
+    at: new Date().toISOString(),
+    action,
+    fromStatus: fromStatus ?? null,
+    toStatus: toStatus ?? null,
+    actor: actor ?? 'system',
+    detail: detail ?? '',
+  };
+}
+
+// Validates a transition and returns the new status plus the audit entry to append.
+// Does not touch persistence.
+export function transition({ from, to, actor, detail }) {
+  assertTransition(from, to);
+  return {
+    status: to,
+    entry: buildAuditEntry({
+      action: 'status_change',
+      fromStatus: from,
+      toStatus: to,
+      actor,
+      detail,
+    }),
+  };
+}
+
+export function appendAudit(log, entry) {
+  return [...(Array.isArray(log) ? log : []), entry];
+}

--- a/src/lib/documents/types.ts
+++ b/src/lib/documents/types.ts
@@ -1,0 +1,40 @@
+export type DocumentStatus =
+  | 'intake_needed'
+  | 'ready_for_review'
+  | 'needs_manual_review'
+  | 'generated'
+  | 'delivered'
+  | 'blocked';
+
+export type TemplateKey = 'diy_kit' | 'expert_review' | 'full_service';
+
+export interface TemplateSection {
+  heading: string;
+  body: string[];
+}
+
+export interface TemplateDefinition {
+  key: TemplateKey;
+  title: string;
+  productLabel: string;
+  requiresHumanReview: boolean;
+  requiresOfficialCourtForms: boolean;
+  sections: TemplateSection[];
+  checklist: string[];
+}
+
+export interface AuditEntry {
+  at: string;
+  action: string;
+  fromStatus: DocumentStatus | null;
+  toStatus: DocumentStatus | null;
+  actor: string;
+  detail: string;
+}
+
+export interface PacketInput {
+  templateKey: TemplateKey;
+  recipientLabel?: string;
+  referenceCode?: string;
+  generatedAt?: string;
+}


### PR DESCRIPTION
## Summary

Adds production-minded **Phase 1 document automation**: turns a paid checkout into a tracked **document package** with a lifecycle status machine, a template registry, a **dependency-free** branded PDF generator, a **human-review gate**, an internal/admin API, and PII-safe handling. Builds incrementally on `main`; does not touch the modern design or Vercel analytics, and keeps DIY at $97.

**Safety posture:** This does NOT generate official California court form content (e.g. CR-180) or auto-deliver personalized legal filings. Phase 1 produces a gated, **non-personalized** informational packet (cover sheet + checklist) that explicitly states an official form template and human review are required before any filing.

### What's included
- **`DocumentPackages` collection** (admin/superadmin gated) with status machine: `intake_needed → ready_for_review → generated → delivered`, plus `needs_manual_review` / `blocked`. Stores only an idempotency key, template key, status, operational email, relationship links, review gate, generated-file pointer, and a **non-PII audit log** — sensitive case data stays on `orders.caseDetails`.
- **Template registry** for DIY kit, Expert Review, Full Service (review-required flags + checklist content; no court-form field content).
- **Dependency-free PDF generator** (`src/lib/documents/pdf.mjs`) — hand-writes valid PDF bytes (Helvetica, no embedded fonts) to **avoid Vercel build risk** from puppeteer/pdfkit. Includes mandatory disclaimers (no guaranteed expungement, not legal advice, no attorney-client relationship).
- **Human-review gate**: review-required packets cannot generate until approved (enforced in both the status flow and the generate route).
- **Idempotent post-payment hook** wired into the existing Stripe webhook — dedups on the Stripe session id (retry-safe) and is error-swallowing, so a packaging failure can never 500 the webhook or block lead creation.
- **Internal API** under `/api/documents` (list / get / approve / generate), gated by `Authorization: Bearer ${CRON_SECRET}` — same pattern as the existing cron routes. No public endpoints, no insecure admin routes.
- **PII safeguards**: `safeLog` redacts sensitive keys; no analytics events carry client/criminal-record data.
- **Internal README** (`src/lib/documents/README.md`): flow, env vars, staff usage, and the future official-court-form roadmap.

### Architecture note
Pure logic lives in `.mjs` modules (status, registry, pdf, redact, service-core) so it can be unit-tested with zero-dependency `node --test` on Node 20 (which can't import `.ts`). Thin typed `.ts` wrappers expose the same logic to the app — single source of truth, **no new dependencies**.

## Files changed
- New: `src/collections/DocumentPackages.ts`; `src/lib/documents/*` (status/registry/disclaimers/pdf/redact/service-core/service/index/types + README + tests); `src/app/api/documents/**` (4 routes + `_auth`).
- Modified: `payload.config.ts` (register collection), `src/app/api/webhook/route.ts` (additive idempotent hook), `package.json` (`test`, `typecheck` scripts — no deps added).

## Testing
- [x] `npm install` — no new dependencies; lockfile unchanged.
- [x] `npm test` (`node --test`) — **23/23 pass** (status transitions, template selection, idempotency, review gating, PDF validity, PII redaction).
- [x] `npm run build` (`next build`) — **compiles successfully**; all 4 `/api/documents` routes registered. (Next.js still 15.3.9; analytics untouched.)
- [x] `npx tsc --noEmit` — **no errors in any new/changed file**. (Several unrelated pre-existing type errors remain on `main`; `next build` skips type validation and is unaffected.)

## Decisions / follow-ups for the team
1. **Internal API auth** uses `Bearer CRON_SECRET`; staff also manage packages via the role-gated Payload admin UI. Confirm this matches ops, or switch to Payload user-session auth if preferred.
2. **Delivery**: generated PDFs are stored as admin-gated Payload media. No public download route yet — a signed-download route backed by `downloadToken` is designed but deferred.
3. **Official court forms** (CR-180 etc.) + deterministic data mapping + signed download are explicit future phases (see README).
4. **Separate security issue (not fixed here):** `src/app/api/send-expungement-packet/route.ts` has hard-coded credentials, a fixed recipient, and CR-180 copy — recommend a follow-up cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)