### PR TITLE
Add secure staff dashboard for document-package review and official packet generation

### DIFF
--- a/src/app/admin-panel/document-packages/page.tsx
+++ b/src/app/admin-panel/document-packages/page.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { headers as nextHeaders } from 'next/headers';
+import { getPayload } from 'payload';
+import config from '@payload-config';
+import DocumentPackagesDashboard from '@/components/staff/DocumentPackagesDashboard';
+
+export const dynamic = 'force-dynamic';
+
+// Staff document-packages dashboard. Server-side authentication gate: only an authenticated
+// admin/superadmin Payload user may render the dashboard. This page issues no data itself —
+// the client component calls the session-authenticated /api/staff/* routes, which re-check
+// authorization on every request (defense in depth).
+export default async function DocumentPackagesPage() {
+  let role: string | null = null;
+  try {
+    const payload = await getPayload({ config });
+    const { user } = await payload.auth({ headers: await nextHeaders() });
+    role = user?.role ?? null;
+  } catch {
+    role = null;
+  }
+
+  const authorized = role === 'admin' || role === 'superadmin';
+
+  if (!authorized) {
+    return (
+      <div
+        data-testid="staff-unauthorized"
+        className="min-h-screen flex items-center justify-center bg-gray-50 p-6"
+      >
+        <div className="max-w-md text-center bg-white border border-gray-200 rounded-xl p-8">
+          <h1 className="text-lg font-semibold text-gray-900">Staff sign-in required</h1>
+          <p className="mt-2 text-sm text-gray-600">
+            This operational dashboard is restricted to authorized staff. Please sign in to the
+            admin panel with an admin account to continue.
+          </p>
+          <a
+            href="/admin"
+            className="mt-4 inline-block px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700"
+          >
+            Go to admin sign-in
+          </a>
+        </div>
+      </div>
+    );
+  }
+
+  return <DocumentPackagesDashboard />;
+}

--- a/src/app/api/staff/_session.ts
+++ b/src/app/api/staff/_session.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getPayload } from 'payload';
+import config from '@payload-config';
+import type { Payload } from 'payload';
+
+// Staff-session authorization for the staff dashboard endpoints.
+//
+// Unlike the CRON_SECRET-gated internal routes (src/app/api/documents/*), these endpoints
+// back a browser-facing operational dashboard, so they authenticate the logged-in Payload
+// user via the session cookie and require an admin/superadmin role. This reuses the same
+// auth that protects the Payload admin UI — no new, weaker credential is introduced, and
+// these routes are never public.
+export type StaffRole = 'admin' | 'superadmin';
+
+export interface StaffSession {
+  payload: Payload;
+  user: { id: string | number; email?: string; role?: string };
+  actor: string;
+}
+
+const STAFF_ROLES: StaffRole[] = ['admin', 'superadmin'];
+
+// Resolves and authorizes the staff session. Returns either an error `response` to return
+// immediately, or the authenticated `session`. Errors are intentionally terse (no internal
+// detail) and never echo back request data.
+export async function requireStaff(
+  request: NextRequest,
+): Promise<{ response: NextResponse } | { session: StaffSession }> {
+  let payload: Payload;
+  try {
+    payload = await getPayload({ config });
+  } catch {
+    return { response: NextResponse.json({ error: 'Service unavailable' }, { status: 503 }) };
+  }
+
+  let user: any = null;
+  try {
+    const result = await payload.auth({ headers: request.headers });
+    user = result?.user ?? null;
+  } catch {
+    user = null;
+  }
+
+  if (!user) {
+    return { response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) };
+  }
+  if (!STAFF_ROLES.includes(user.role)) {
+    return { response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) };
+  }
+
+  const actor =
+    (typeof user.email === 'string' && user.email) ||
+    (user.id != null ? `user:${user.id}` : 'staff');
+
+  return { session: { payload, user, actor } };
+}

--- a/src/app/api/staff/document-packages/[id]/approve/route.ts
+++ b/src/app/api/staff/document-packages/[id]/approve/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireStaff } from '../../../_session';
+import { approvePackage } from '@/lib/documents/service';
+
+// POST /api/staff/document-packages/[id]/approve — record human-review approval from the
+// staff dashboard. Session-authenticated (admin/superadmin). The reviewer is the logged-in
+// staff user (actor), not a client-supplied value. Body: { notes?: string }
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await requireStaff(request);
+  if ('response' in auth) return auth.response;
+  const { payload, actor } = auth.session;
+
+  try {
+    const { id } = await params;
+    const body = await request.json().catch(() => ({}));
+    const notes = typeof body.notes === 'string' ? body.notes : undefined;
+    const result = await approvePackage(payload, { id, actor, notes });
+    return NextResponse.json({ success: true, ...result });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Approval failed';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/src/app/api/staff/document-packages/[id]/generate/route.ts
+++ b/src/app/api/staff/document-packages/[id]/generate/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireStaff } from '../../../_session';
+import { generateOfficialPacket } from '@/lib/documents/service';
+
+// POST /api/staff/document-packages/[id]/generate — trigger official CR-180/CR-181 packet
+// generation from the staff dashboard. Session-authenticated (admin/superadmin).
+//
+// The intake is NOT taken from the request body — it is read from the staff-reviewed
+// `officialIntake` already saved on the package (see save-intake). Generation stays blocked
+// (409) unless the human-review gate is approved AND the saved intake validates. The packet
+// is left at `generated` (never auto-delivered). Body: { sample?: boolean }
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await requireStaff(request);
+  if ('response' in auth) return auth.response;
+  const { payload, actor } = auth.session;
+
+  try {
+    const { id } = await params;
+    const body = await request.json().catch(() => ({}));
+    const sample = body.sample === true;
+    const result = await generateOfficialPacket(payload, { id, actor, sample });
+
+    if (result.blocked) {
+      return NextResponse.json(
+        {
+          success: false,
+          blocked: true,
+          status: result.status,
+          reasons: result.reasons,
+          error: 'Official packet not generated; see reasons',
+        },
+        { status: 409 },
+      );
+    }
+    return NextResponse.json({ success: true, ...result });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Official generation failed';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/src/app/api/staff/document-packages/[id]/route.ts
+++ b/src/app/api/staff/document-packages/[id]/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireStaff } from '../../_session';
+import { serializeDetail } from '../_serialize';
+
+// GET /api/staff/document-packages/[id] — single package detail for the staff review view.
+// Session-authenticated (admin/superadmin). Returns stored intake + validation + audit log.
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await requireStaff(request);
+  if ('response' in auth) return auth.response;
+  const { payload } = auth.session;
+
+  try {
+    const { id } = await params;
+    const doc = await payload.findByID({
+      collection: 'document-packages' as any,
+      id,
+      depth: 0,
+    });
+    return NextResponse.json({ success: true, doc: serializeDetail(doc as any) });
+  } catch {
+    return NextResponse.json({ error: 'Document package not found' }, { status: 404 });
+  }
+}

--- a/src/app/api/staff/document-packages/[id]/save-intake/route.ts
+++ b/src/app/api/staff/document-packages/[id]/save-intake/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireStaff } from '../../../_session';
+import { parseIntakeBody } from '../../_intake';
+import { saveOfficialIntake } from '@/lib/documents/service';
+
+// POST /api/staff/document-packages/[id]/save-intake — persist staff-reviewed official
+// intake. Session-authenticated (admin/superadmin). Does NOT generate; returns the
+// validation result so the UI can render the missing-field checklist.
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await requireStaff(request);
+  if ('response' in auth) return auth.response;
+  const { payload, actor } = auth.session;
+
+  try {
+    const { id } = await params;
+    const body = await request.json().catch(() => ({}));
+    const intake = parseIntakeBody(body);
+    const result = await saveOfficialIntake(payload, { id, actor, intake });
+    return NextResponse.json({ success: true, validation: result.validation });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to save intake';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/src/app/api/staff/document-packages/_intake.ts
+++ b/src/app/api/staff/document-packages/_intake.ts
@@ -1,0 +1,56 @@
+import type { OfficialIntake } from '@/lib/documents/types';
+
+// Coerces an untrusted JSON body from the staff dashboard into the canonical OfficialIntake
+// shape. Only known fields are read; anything else is dropped. No validation of legal
+// correctness happens here — that lives in official/mapping.mjs and is invoked by the
+// service layer. This is purely structural shaping at the system boundary.
+export function parseIntakeBody(body: unknown): OfficialIntake {
+  const b = (body && typeof body === 'object' ? body : {}) as Record<string, any>;
+  const p = b.petitioner || {};
+  const court = b.court || {};
+  const c = b.case || b.caseInfo || {};
+  const relief = b.relief || {};
+
+  const charges = Array.isArray(c.charges)
+    ? c.charges
+        .map((x: any) => ({
+          code: str(x?.code),
+          section: str(x?.section),
+          type: str(x?.type),
+        }))
+        .filter((x: any) => x.code || x.section || x.type)
+    : [];
+
+  return {
+    staffReviewed: b.staffReviewed === true,
+    selfRepresented: b.selfRepresented === true,
+    petitioner: {
+      fullName: str(p.fullName),
+      street: str(p.street),
+      city: str(p.city),
+      state: str(p.state),
+      zip: str(p.zip),
+      phone: str(p.phone),
+      email: str(p.email),
+    },
+    court: {
+      county: str(court.county),
+      courtName: str(court.courtName),
+      courtStreet: str(court.courtStreet),
+      courtCityZip: str(court.courtCityZip),
+    },
+    case: {
+      caseNumber: str(c.caseNumber),
+      convictionDate: str(c.convictionDate),
+      charges,
+    },
+    relief: {
+      dismissalBasis: str(relief.dismissalBasis) as OfficialIntake['relief']['dismissalBasis'],
+      felonyReductionRequested: relief.felonyReductionRequested === true,
+    },
+  };
+}
+
+function str(v: unknown): string {
+  return typeof v === 'string' ? v.trim() : '';
+}

--- a/src/app/api/staff/document-packages/_serialize.ts
+++ b/src/app/api/staff/document-packages/_serialize.ts
@@ -1,0 +1,81 @@
+// Serializers that shape document-package records for the staff dashboard. The list view
+// deliberately omits intake PII (petitioner name, case number, charges); only the detail
+// view returns the stored intake so staff can edit it. Generated PDFs are never exposed via
+// a URL here — only non-PII artifact metadata is returned.
+
+interface AnyDoc {
+  id: string | number;
+  sourceSessionId?: string;
+  templateKey?: string;
+  status?: string;
+  customerEmail?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  review?: { approved?: boolean; reviewedBy?: string; reviewedAt?: string; reviewNotes?: string };
+  validation?: { ok?: boolean; reasons?: Array<{ reason?: string }>; checkedAt?: string };
+  generatedArtifact?: { fileName?: string; byteSize?: number; sample?: boolean; generatedAt?: string };
+  generatedFile?: unknown;
+  officialIntake?: Record<string, unknown>;
+  auditLog?: Array<Record<string, unknown>>;
+}
+
+function reasons(doc: AnyDoc): string[] {
+  return Array.isArray(doc.validation?.reasons)
+    ? doc.validation!.reasons!.map((r) => r?.reason).filter((r): r is string => !!r)
+    : [];
+}
+
+// List item: no intake PII. customerEmail is an operational lookup already stored on the
+// collection and shown only to authorized staff.
+export function serializeListItem(doc: AnyDoc) {
+  return {
+    id: doc.id,
+    sourceSessionId: doc.sourceSessionId,
+    templateKey: doc.templateKey,
+    status: doc.status,
+    customerEmail: doc.customerEmail ?? null,
+    isOfficial: doc.templateKey === 'official_ca_dismissal_packet',
+    reviewApproved: doc.review?.approved === true,
+    validationOk: doc.validation?.ok === true,
+    validationIssueCount: reasons(doc).length,
+    hasArtifact: !!doc.generatedFile,
+    createdAt: doc.createdAt,
+    updatedAt: doc.updatedAt,
+  };
+}
+
+// Detail: includes the stored official intake (PII) so staff can review/edit, plus
+// validation reasons, review state, artifact metadata, and the non-PII audit log.
+export function serializeDetail(doc: AnyDoc) {
+  return {
+    id: doc.id,
+    sourceSessionId: doc.sourceSessionId,
+    templateKey: doc.templateKey,
+    status: doc.status,
+    customerEmail: doc.customerEmail ?? null,
+    isOfficial: doc.templateKey === 'official_ca_dismissal_packet',
+    review: {
+      approved: doc.review?.approved === true,
+      reviewedBy: doc.review?.reviewedBy ?? null,
+      reviewedAt: doc.review?.reviewedAt ?? null,
+      reviewNotes: doc.review?.reviewNotes ?? null,
+    },
+    validation: {
+      ok: doc.validation?.ok === true,
+      reasons: reasons(doc),
+      checkedAt: doc.validation?.checkedAt ?? null,
+    },
+    officialIntake: doc.officialIntake ?? null,
+    generatedArtifact: doc.generatedFile
+      ? {
+          fileName: doc.generatedArtifact?.fileName ?? null,
+          byteSize: doc.generatedArtifact?.byteSize ?? null,
+          sample: doc.generatedArtifact?.sample === true,
+          generatedAt: doc.generatedArtifact?.generatedAt ?? null,
+        }
+      : null,
+    auditLog: Array.isArray(doc.auditLog) ? doc.auditLog : [],
+    createdAt: doc.createdAt,
+    updatedAt: doc.updatedAt,
+  };
+}

--- a/src/app/api/staff/document-packages/route.ts
+++ b/src/app/api/staff/document-packages/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireStaff } from '../_session';
+import { serializeListItem } from './_serialize';
+
+// GET /api/staff/document-packages — list document packages for the staff dashboard.
+// Session-authenticated (admin/superadmin). Returns PII-light list items only.
+//
+// Query: ?status=<status>&official=1&limit=<n>&page=<n>
+export async function GET(request: NextRequest) {
+  const auth = await requireStaff(request);
+  if ('response' in auth) return auth.response;
+  const { payload } = auth.session;
+
+  const { searchParams } = new URL(request.url);
+  const status = searchParams.get('status');
+  const officialOnly = searchParams.get('official') === '1';
+  const limit = Math.min(Number(searchParams.get('limit')) || 50, 200);
+  const page = Math.max(Number(searchParams.get('page')) || 1, 1);
+
+  const where: Record<string, unknown> = {};
+  if (status) where.status = { equals: status };
+  if (officialOnly) where.templateKey = { equals: 'official_ca_dismissal_packet' };
+
+  try {
+    const result = await payload.find({
+      collection: 'document-packages' as any,
+      where,
+      limit,
+      page,
+      sort: '-createdAt',
+      depth: 0,
+    });
+    return NextResponse.json({
+      success: true,
+      docs: result.docs.map(serializeListItem),
+      totalDocs: result.totalDocs,
+      page: result.page,
+      totalPages: result.totalPages,
+    });
+  } catch {
+    return NextResponse.json({ error: 'Failed to load document packages' }, { status: 500 });
+  }
+}

--- a/src/collections/DocumentPackages.ts
+++ b/src/collections/DocumentPackages.ts
@@ -99,12 +99,124 @@ const DocumentPackages: CollectionConfig = {
       ],
     },
     {
+      name: 'officialIntake',
+      type: 'group',
+      admin: {
+        description:
+          'Staff-reviewed intake for official CR-180/CR-181 generation. Contains case PII; ' +
+          'admin-gated, never logged or sent to analytics. Every legal choice here must be ' +
+          'entered by a human reviewer — never inferred from marketing-quiz answers.',
+        condition: (data) => data?.templateKey === 'official_ca_dismissal_packet',
+      },
+      fields: [
+        {
+          name: 'staffReviewed',
+          type: 'checkbox',
+          defaultValue: false,
+          admin: { description: 'Hard gate: must be true before generation can fill official forms.' },
+        },
+        { name: 'selfRepresented', type: 'checkbox', defaultValue: false },
+        {
+          name: 'petitioner',
+          type: 'group',
+          fields: [
+            { name: 'fullName', type: 'text' },
+            { name: 'street', type: 'text' },
+            { name: 'city', type: 'text' },
+            { name: 'state', type: 'text' },
+            { name: 'zip', type: 'text' },
+            { name: 'phone', type: 'text' },
+            { name: 'email', type: 'email' },
+          ],
+        },
+        {
+          name: 'court',
+          type: 'group',
+          fields: [
+            { name: 'county', type: 'text' },
+            { name: 'courtName', type: 'text' },
+            { name: 'courtStreet', type: 'text' },
+            { name: 'courtCityZip', type: 'text' },
+          ],
+        },
+        {
+          name: 'caseInfo',
+          type: 'group',
+          fields: [
+            { name: 'caseNumber', type: 'text' },
+            { name: 'convictionDate', type: 'text' },
+            {
+              name: 'charges',
+              type: 'array',
+              fields: [
+                { name: 'code', type: 'text' },
+                { name: 'section', type: 'text' },
+                { name: 'type', type: 'text' },
+              ],
+            },
+          ],
+        },
+        {
+          name: 'relief',
+          type: 'group',
+          fields: [
+            {
+              name: 'dismissalBasis',
+              type: 'select',
+              options: [
+                { label: '§ 1203.4 — probation granted', value: '1203.4' },
+                { label: '§ 1203.4a — non-probation misdemeanor/infraction', value: '1203.4a' },
+                { label: '§ 1203.41 — felony jail/prison', value: '1203.41' },
+                { label: '§ 1203.42 — pre-realignment felony prison', value: '1203.42' },
+                { label: '§ 1203.49 — § 647(b) trafficking victim', value: '1203.49' },
+              ],
+            },
+            { name: 'felonyReductionRequested', type: 'checkbox', defaultValue: false },
+          ],
+        },
+        { name: 'savedBy', type: 'text', admin: { readOnly: true } },
+        { name: 'savedAt', type: 'date', admin: { readOnly: true, date: { pickerAppearance: 'dayAndTime' } } },
+      ],
+    },
+    {
+      name: 'validation',
+      type: 'group',
+      admin: {
+        readOnly: true,
+        description: 'Last validation result for the official intake. Reasons are non-PII strings only.',
+        condition: (data) => data?.templateKey === 'official_ca_dismissal_packet',
+      },
+      fields: [
+        { name: 'ok', type: 'checkbox', defaultValue: false },
+        {
+          name: 'reasons',
+          type: 'array',
+          fields: [{ name: 'reason', type: 'text' }],
+        },
+        { name: 'checkedAt', type: 'date', admin: { date: { pickerAppearance: 'dayAndTime' } } },
+      ],
+    },
+    {
       name: 'generatedFile',
       type: 'upload',
       relationTo: 'media',
       admin: {
         description: 'Generated PDF packet (admin-gated storage). No public download route exists yet.',
       },
+    },
+    {
+      name: 'generatedArtifact',
+      type: 'group',
+      admin: {
+        readOnly: true,
+        description: 'Non-PII metadata about the most recently generated packet artifact.',
+      },
+      fields: [
+        { name: 'fileName', type: 'text' },
+        { name: 'byteSize', type: 'number' },
+        { name: 'sample', type: 'checkbox', defaultValue: false },
+        { name: 'generatedAt', type: 'date', admin: { date: { pickerAppearance: 'dayAndTime' } } },
+      ],
     },
     {
       name: 'downloadToken',

--- a/src/components/staff/DocumentPackagesDashboard.tsx
+++ b/src/components/staff/DocumentPackagesDashboard.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { STATUS_LABELS, STATUS_CHIP_CLASS, TEMPLATE_LABELS } from './constants';
+import OfficialPackageReview from './OfficialPackageReview';
+
+export interface PackageListItem {
+  id: string | number;
+  sourceSessionId?: string;
+  templateKey?: string;
+  status?: string;
+  customerEmail?: string | null;
+  isOfficial?: boolean;
+  reviewApproved?: boolean;
+  validationOk?: boolean;
+  validationIssueCount?: number;
+  hasArtifact?: boolean;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+function StatusChip({ status }: { status?: string }) {
+  if (!status) return null;
+  return (
+    <span
+      data-testid="status-chip"
+      className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${
+        STATUS_CHIP_CLASS[status] || 'bg-gray-100 text-gray-800'
+      }`}
+    >
+      {STATUS_LABELS[status] || status}
+    </span>
+  );
+}
+
+export default function DocumentPackagesDashboard() {
+  const [docs, setDocs] = useState<PackageListItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [statusFilter, setStatusFilter] = useState('');
+  const [officialOnly, setOfficialOnly] = useState(false);
+  const [selectedId, setSelectedId] = useState<string | number | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      if (statusFilter) params.set('status', statusFilter);
+      if (officialOnly) params.set('official', '1');
+      const res = await fetch(`/api/staff/document-packages?${params.toString()}`, {
+        credentials: 'include',
+      });
+      if (res.status === 401 || res.status === 403) {
+        setError('Your session is not authorized. Please sign in to the admin panel.');
+        setDocs([]);
+        return;
+      }
+      if (!res.ok) throw new Error('Failed to load');
+      const data = await res.json();
+      setDocs(data.docs || []);
+    } catch {
+      setError('Could not load document packages. Please retry.');
+    } finally {
+      setLoading(false);
+    }
+  }, [statusFilter, officialOnly]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return (
+    <div className="min-h-screen bg-gray-50" data-testid="staff-dashboard">
+      <div className="bg-white border-b border-gray-200">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+          <h1 className="text-xl font-bold text-gray-900">Document Packages</h1>
+          <p className="text-xs text-gray-500 mt-1">
+            Review paid-order document packages and generate official CA dismissal packets.
+          </p>
+        </div>
+      </div>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+        <div className="grid grid-cols-1 lg:grid-cols-5 gap-6">
+          {/* List */}
+          <div className="lg:col-span-3">
+            <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+              <div className="px-4 py-3 border-b border-gray-200 bg-gray-50 flex flex-wrap items-center gap-3">
+                <select
+                  data-testid="status-filter"
+                  value={statusFilter}
+                  onChange={(e) => setStatusFilter(e.target.value)}
+                  className="text-sm border border-gray-300 rounded-lg px-3 py-1.5"
+                >
+                  <option value="">All statuses</option>
+                  {Object.entries(STATUS_LABELS).map(([v, l]) => (
+                    <option key={v} value={v}>
+                      {l}
+                    </option>
+                  ))}
+                </select>
+                <label className="flex items-center gap-1.5 text-sm text-gray-700">
+                  <input
+                    data-testid="official-filter"
+                    type="checkbox"
+                    checked={officialOnly}
+                    onChange={(e) => setOfficialOnly(e.target.checked)}
+                  />
+                  Official only
+                </label>
+                <button
+                  data-testid="refresh-list"
+                  onClick={load}
+                  className="ml-auto text-xs font-medium text-blue-600 hover:text-blue-800"
+                >
+                  Refresh
+                </button>
+              </div>
+
+              {loading ? (
+                <div className="p-8 text-center text-sm text-gray-500" data-testid="list-loading">
+                  Loading document packages…
+                </div>
+              ) : error ? (
+                <div className="p-8 text-center text-sm text-red-600" data-testid="list-error">
+                  {error}
+                </div>
+              ) : docs.length === 0 ? (
+                <div className="p-8 text-center text-sm text-gray-500" data-testid="list-empty">
+                  No document packages match this filter.
+                </div>
+              ) : (
+                <div className="overflow-x-auto">
+                  <table className="min-w-full">
+                    <thead className="bg-gray-50 border-b border-gray-200">
+                      <tr>
+                        <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Reference</th>
+                        <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Type</th>
+                        <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
+                        <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Checks</th>
+                        <th className="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">Action</th>
+                      </tr>
+                    </thead>
+                    <tbody className="bg-white divide-y divide-gray-200" data-testid="package-rows">
+                      {docs.map((d) => (
+                        <tr
+                          key={String(d.id)}
+                          className={`hover:bg-gray-50 ${selectedId === d.id ? 'bg-blue-50' : ''}`}
+                        >
+                          <td className="px-4 py-3">
+                            <p className="text-sm font-medium text-gray-900 truncate max-w-[180px]">
+                              {d.sourceSessionId}
+                            </p>
+                            {d.customerEmail && (
+                              <p className="text-xs text-gray-500 truncate max-w-[180px]">{d.customerEmail}</p>
+                            )}
+                          </td>
+                          <td className="px-4 py-3 text-xs text-gray-700">
+                            {TEMPLATE_LABELS[d.templateKey || ''] || d.templateKey}
+                          </td>
+                          <td className="px-4 py-3">
+                            <StatusChip status={d.status} />
+                          </td>
+                          <td className="px-4 py-3">
+                            <div className="flex flex-col gap-1 text-xs">
+                              <span className={d.reviewApproved ? 'text-green-700' : 'text-gray-400'}>
+                                {d.reviewApproved ? '✓ Approved' : '○ Not approved'}
+                              </span>
+                              {d.isOfficial && (
+                                <span className={d.validationOk ? 'text-green-700' : 'text-amber-700'}>
+                                  {d.validationOk
+                                    ? '✓ Intake valid'
+                                    : `${d.validationIssueCount ?? 0} issue(s)`}
+                                </span>
+                              )}
+                              {d.hasArtifact && <span className="text-emerald-700">✓ Packet</span>}
+                            </div>
+                          </td>
+                          <td className="px-4 py-3 text-right">
+                            <button
+                              data-testid={`open-${d.id}`}
+                              onClick={() => setSelectedId(d.id)}
+                              className="px-3 py-1 text-xs font-medium text-blue-600 hover:text-blue-800 hover:bg-blue-50 rounded"
+                            >
+                              Open
+                            </button>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Detail / review */}
+          <div className="lg:col-span-2">
+            {selectedId == null ? (
+              <div
+                data-testid="detail-empty"
+                className="bg-white rounded-xl border border-gray-200 p-8 text-center text-sm text-gray-500"
+              >
+                Select a package to review its intake and generate the official packet.
+              </div>
+            ) : (
+              <OfficialPackageReview
+                key={String(selectedId)}
+                packageId={selectedId}
+                onChanged={load}
+                onClose={() => setSelectedId(null)}
+              />
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/staff/OfficialPackageReview.tsx
+++ b/src/components/staff/OfficialPackageReview.tsx
@@ -1,0 +1,429 @@
+'use client';
+
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  DISMISSAL_BASIS_OPTIONS,
+  SUPPORTED_COUNTY_OPTIONS,
+  STATUS_LABELS,
+  STATUS_CHIP_CLASS,
+  TEMPLATE_LABELS,
+} from './constants';
+
+interface Charge {
+  code?: string;
+  section?: string;
+  type?: string;
+}
+
+interface IntakeForm {
+  staffReviewed: boolean;
+  selfRepresented: boolean;
+  petitioner: { fullName: string; street: string; city: string; state: string; zip: string; phone: string; email: string };
+  court: { county: string; courtName: string; courtStreet: string; courtCityZip: string };
+  caseInfo: { caseNumber: string; convictionDate: string; charges: Charge[] };
+  relief: { dismissalBasis: string; felonyReductionRequested: boolean };
+}
+
+interface Detail {
+  id: string | number;
+  sourceSessionId?: string;
+  templateKey?: string;
+  status?: string;
+  customerEmail?: string | null;
+  isOfficial?: boolean;
+  review: { approved: boolean; reviewedBy?: string | null; reviewedAt?: string | null; reviewNotes?: string | null };
+  validation: { ok: boolean; reasons: string[]; checkedAt?: string | null };
+  officialIntake?: any;
+  generatedArtifact?: { fileName?: string | null; byteSize?: number | null; sample?: boolean; generatedAt?: string | null } | null;
+  auditLog: Array<{ at?: string; action?: string; actor?: string; detail?: string; fromStatus?: string; toStatus?: string }>;
+}
+
+const emptyForm = (): IntakeForm => ({
+  staffReviewed: false,
+  selfRepresented: false,
+  petitioner: { fullName: '', street: '', city: '', state: '', zip: '', phone: '', email: '' },
+  court: { county: '', courtName: '', courtStreet: '', courtCityZip: '' },
+  caseInfo: { caseNumber: '', convictionDate: '', charges: [{ code: '', section: '', type: '' }] },
+  relief: { dismissalBasis: '', felonyReductionRequested: false },
+});
+
+function formFromStored(stored: any): IntakeForm {
+  const f = emptyForm();
+  if (!stored || typeof stored !== 'object') return f;
+  f.staffReviewed = stored.staffReviewed === true;
+  f.selfRepresented = stored.selfRepresented === true;
+  Object.assign(f.petitioner, sanitize(stored.petitioner));
+  Object.assign(f.court, sanitize(stored.court));
+  const ci = stored.caseInfo || {};
+  f.caseInfo.caseNumber = str(ci.caseNumber);
+  f.caseInfo.convictionDate = str(ci.convictionDate);
+  f.caseInfo.charges =
+    Array.isArray(ci.charges) && ci.charges.length
+      ? ci.charges.map((c: any) => ({ code: str(c.code), section: str(c.section), type: str(c.type) }))
+      : [{ code: '', section: '', type: '' }];
+  f.relief.dismissalBasis = str(stored.relief?.dismissalBasis);
+  f.relief.felonyReductionRequested = stored.relief?.felonyReductionRequested === true;
+  return f;
+}
+
+function sanitize(obj: any): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (obj && typeof obj === 'object') for (const [k, v] of Object.entries(obj)) out[k] = str(v);
+  return out;
+}
+function str(v: unknown): string {
+  return typeof v === 'string' ? v : '';
+}
+
+export default function OfficialPackageReview({
+  packageId,
+  onChanged,
+  onClose,
+}: {
+  packageId: string | number;
+  onChanged: () => void;
+  onClose: () => void;
+}) {
+  const [detail, setDetail] = useState<Detail | null>(null);
+  const [form, setForm] = useState<IntakeForm>(emptyForm());
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/staff/document-packages/${packageId}`, { credentials: 'include' });
+      if (res.status === 401 || res.status === 403) {
+        setError('Not authorized.');
+        return;
+      }
+      if (!res.ok) throw new Error('not found');
+      const data = await res.json();
+      setDetail(data.doc);
+      setForm(formFromStored(data.doc.officialIntake));
+    } catch {
+      setError('Could not load this package.');
+    } finally {
+      setLoading(false);
+    }
+  }, [packageId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const post = async (path: string, body: any) => {
+    setBusy(path);
+    setMessage(null);
+    setError(null);
+    try {
+      const res = await fetch(`/api/staff/document-packages/${packageId}${path}`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (res.status === 401 || res.status === 403) {
+        setError('Your session is not authorized.');
+        return null;
+      }
+      if (res.status === 409) {
+        setError('Blocked: ' + (data.reasons?.join(' ') || data.error || 'see validation.'));
+        await load();
+        return data;
+      }
+      if (!res.ok) {
+        setError(data.error || 'Request failed.');
+        return null;
+      }
+      await load();
+      onChanged();
+      return data;
+    } catch {
+      setError('Request failed. Please retry.');
+      return null;
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const buildIntakeBody = () => ({
+    staffReviewed: form.staffReviewed,
+    selfRepresented: form.selfRepresented,
+    petitioner: { ...form.petitioner },
+    court: { ...form.court },
+    case: {
+      caseNumber: form.caseInfo.caseNumber,
+      convictionDate: form.caseInfo.convictionDate,
+      charges: form.caseInfo.charges,
+    },
+    relief: { ...form.relief },
+  });
+
+  const saveIntake = async () => {
+    const data = await post('/save-intake', buildIntakeBody());
+    if (data?.validation) {
+      setMessage(data.validation.ok ? 'Intake saved — passes validation.' : 'Intake saved.');
+    }
+  };
+  const approve = async (notes: string) => {
+    const data = await post('/approve', { notes });
+    if (data?.success) setMessage('Review approved.');
+  };
+  const generate = async (sample: boolean) => {
+    const data = await post('/generate', { sample });
+    if (data?.success) setMessage(sample ? 'Sample packet generated.' : 'Official packet generated.');
+  };
+
+  if (loading) {
+    return (
+      <div data-testid="detail-loading" className="bg-white rounded-xl border border-gray-200 p-8 text-center text-sm text-gray-500">
+        Loading package…
+      </div>
+    );
+  }
+  if (error && !detail) {
+    return (
+      <div data-testid="detail-error" className="bg-white rounded-xl border border-gray-200 p-8 text-center text-sm text-red-600">
+        {error}
+      </div>
+    );
+  }
+  if (!detail) return null;
+
+  const isOfficial = detail.isOfficial;
+
+  return (
+    <div className="bg-white rounded-xl border border-gray-200" data-testid="package-detail">
+      <div className="px-4 py-3 border-b border-gray-200 bg-gray-50 flex items-center justify-between">
+        <div>
+          <p className="text-sm font-semibold text-gray-900 truncate max-w-[260px]">{detail.sourceSessionId}</p>
+          <p className="text-xs text-gray-500">{TEMPLATE_LABELS[detail.templateKey || ''] || detail.templateKey}</p>
+        </div>
+        <button onClick={onClose} className="text-gray-400 hover:text-gray-600 text-sm" data-testid="detail-close">
+          Close
+        </button>
+      </div>
+
+      <div className="p-4 space-y-4">
+        <div className="flex items-center gap-2">
+          <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${STATUS_CHIP_CLASS[detail.status || ''] || 'bg-gray-100 text-gray-800'}`}>
+            {STATUS_LABELS[detail.status || ''] || detail.status}
+          </span>
+          {detail.review.approved && <span className="text-xs text-green-700">✓ Review approved</span>}
+        </div>
+
+        {message && <div data-testid="detail-message" className="text-xs text-green-700 bg-green-50 rounded p-2">{message}</div>}
+        {error && <div data-testid="detail-action-error" className="text-xs text-red-700 bg-red-50 rounded p-2">{error}</div>}
+
+        {!isOfficial ? (
+          <div className="text-sm text-gray-600">
+            This package type ({TEMPLATE_LABELS[detail.templateKey || ''] || detail.templateKey}) does not use
+            the official CR-180/CR-181 intake. Manage it from the standard review flow.
+          </div>
+        ) : (
+          <>
+            {/* Validation checklist */}
+            <div className="rounded-lg border border-gray-200 p-3" data-testid="validation-panel">
+              <p className="text-xs font-semibold text-gray-700 uppercase tracking-wide">Validation</p>
+              {detail.validation.ok ? (
+                <p className="mt-1 text-sm text-green-700">All required fields present. Ready to generate once approved.</p>
+              ) : detail.validation.reasons.length ? (
+                <ul className="mt-1 list-disc list-inside text-sm text-amber-700" data-testid="validation-reasons">
+                  {detail.validation.reasons.map((r, i) => (
+                    <li key={i}>{r}</li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="mt-1 text-sm text-gray-500">Save the intake to run validation.</p>
+              )}
+            </div>
+
+            {/* Intake form */}
+            <IntakeFields form={form} setForm={setForm} />
+
+            {/* Actions */}
+            <div className="flex flex-wrap gap-2 pt-2 border-t border-gray-200">
+              <button
+                data-testid="save-review"
+                disabled={!!busy}
+                onClick={saveIntake}
+                className="px-3 py-1.5 text-sm font-medium bg-gray-100 text-gray-800 rounded-lg hover:bg-gray-200 disabled:opacity-50"
+              >
+                {busy === '/save-intake' ? 'Saving…' : 'Save Review'}
+              </button>
+              <button
+                data-testid="approve-intake"
+                disabled={!!busy || detail.review.approved}
+                onClick={() => approve(form.petitioner.fullName ? 'Approved via staff dashboard' : 'Approved')}
+                className="px-3 py-1.5 text-sm font-medium bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50"
+              >
+                {detail.review.approved ? 'Approved' : busy === '/approve' ? 'Approving…' : 'Approve Intake'}
+              </button>
+              <button
+                data-testid="generate-packet"
+                disabled={!!busy || !detail.review.approved}
+                title={!detail.review.approved ? 'Approve the intake first' : undefined}
+                onClick={() => generate(false)}
+                className="px-3 py-1.5 text-sm font-medium bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 disabled:opacity-50"
+              >
+                {busy === '/generate' ? 'Generating…' : 'Generate Official Packet'}
+              </button>
+              <button
+                data-testid="generate-sample"
+                disabled={!!busy || !detail.review.approved}
+                onClick={() => generate(true)}
+                className="px-3 py-1.5 text-sm font-medium text-emerald-700 border border-emerald-300 rounded-lg hover:bg-emerald-50 disabled:opacity-50"
+              >
+                Generate Sample
+              </button>
+            </div>
+
+            {/* Artifact + next steps */}
+            {detail.generatedArtifact && (
+              <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-3 text-sm" data-testid="artifact-panel">
+                <p className="font-medium text-emerald-800">
+                  Packet generated{detail.generatedArtifact.sample ? ' (SAMPLE — not for filing)' : ''}.
+                </p>
+                <p className="text-xs text-emerald-700 mt-1">
+                  {detail.generatedArtifact.fileName} · {detail.generatedArtifact.byteSize ?? '?'} bytes
+                </p>
+                <p className="text-xs text-gray-600 mt-2">
+                  Next (manual): a reviewer retrieves the PDF from admin-gated media storage, verifies the
+                  filled CR-180/CR-181, and handles secure delivery. No public download link exists yet.
+                </p>
+              </div>
+            )}
+          </>
+        )}
+
+        {/* Audit log */}
+        <details className="rounded-lg border border-gray-200 p-3" data-testid="audit-log">
+          <summary className="text-xs font-semibold text-gray-700 uppercase tracking-wide cursor-pointer">
+            Action history ({detail.auditLog.length})
+          </summary>
+          <ul className="mt-2 space-y-1 text-xs text-gray-600">
+            {detail.auditLog.map((e, i) => (
+              <li key={i}>
+                <span className="text-gray-400">{e.at?.slice(0, 19).replace('T', ' ')}</span> · {e.action} · {e.detail}{' '}
+                <span className="text-gray-400">({e.actor})</span>
+              </li>
+            ))}
+          </ul>
+        </details>
+      </div>
+    </div>
+  );
+}
+
+function IntakeFields({ form, setForm }: { form: IntakeForm; setForm: (f: IntakeForm) => void }) {
+  const set = (patch: Partial<IntakeForm>) => setForm({ ...form, ...patch });
+  const setGroup = <K extends keyof IntakeForm>(group: K, patch: Partial<IntakeForm[K]>) =>
+    setForm({ ...form, [group]: { ...(form[group] as any), ...patch } });
+
+  const updateCharge = (idx: number, patch: Partial<Charge>) => {
+    const charges = form.caseInfo.charges.map((c, i) => (i === idx ? { ...c, ...patch } : c));
+    setGroup('caseInfo', { charges });
+  };
+  const addCharge = () => setGroup('caseInfo', { charges: [...form.caseInfo.charges, { code: '', section: '', type: '' }] });
+  const removeCharge = (idx: number) =>
+    setGroup('caseInfo', { charges: form.caseInfo.charges.filter((_, i) => i !== idx) });
+
+  const input = 'w-full text-sm border border-gray-300 rounded-lg px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500';
+  const label = 'block text-xs font-medium text-gray-600 mb-0.5';
+
+  return (
+    <div className="space-y-4" data-testid="intake-form">
+      <Section title="Petitioner">
+        <Field label="Full name"><input className={input} data-testid="f-fullName" value={form.petitioner.fullName} onChange={(e) => setGroup('petitioner', { fullName: e.target.value })} /></Field>
+        <div className="grid grid-cols-2 gap-2">
+          <Field label="Street"><input className={input} value={form.petitioner.street} onChange={(e) => setGroup('petitioner', { street: e.target.value })} /></Field>
+          <Field label="City"><input className={input} value={form.petitioner.city} onChange={(e) => setGroup('petitioner', { city: e.target.value })} /></Field>
+          <Field label="State"><input className={input} value={form.petitioner.state} onChange={(e) => setGroup('petitioner', { state: e.target.value })} /></Field>
+          <Field label="ZIP"><input className={input} value={form.petitioner.zip} onChange={(e) => setGroup('petitioner', { zip: e.target.value })} /></Field>
+          <Field label="Phone"><input className={input} value={form.petitioner.phone} onChange={(e) => setGroup('petitioner', { phone: e.target.value })} /></Field>
+          <Field label="Email"><input className={input} value={form.petitioner.email} onChange={(e) => setGroup('petitioner', { email: e.target.value })} /></Field>
+        </div>
+        <label className="flex items-center gap-1.5 text-sm text-gray-700">
+          <input type="checkbox" checked={form.selfRepresented} onChange={(e) => set({ selfRepresented: e.target.checked })} />
+          Self-represented (in pro per)
+        </label>
+      </Section>
+
+      <Section title="Court">
+        <Field label="County">
+          <select className={input} data-testid="f-county" value={form.court.county} onChange={(e) => setGroup('court', { county: e.target.value })}>
+            <option value="">Select county…</option>
+            {SUPPORTED_COUNTY_OPTIONS.map((c) => (
+              <option key={c.value} value={c.value}>{c.label}</option>
+            ))}
+          </select>
+          <p className="text-xs text-gray-400 mt-0.5">Other counties: enter the county slug and supply the court address below.</p>
+        </Field>
+        <div className="grid grid-cols-2 gap-2">
+          <Field label="Court name"><input className={input} value={form.court.courtName} onChange={(e) => setGroup('court', { courtName: e.target.value })} /></Field>
+          <Field label="Court street"><input className={input} value={form.court.courtStreet} onChange={(e) => setGroup('court', { courtStreet: e.target.value })} /></Field>
+          <Field label="Court city/ZIP"><input className={input} value={form.court.courtCityZip} onChange={(e) => setGroup('court', { courtCityZip: e.target.value })} /></Field>
+        </div>
+      </Section>
+
+      <Section title="Case">
+        <div className="grid grid-cols-2 gap-2">
+          <Field label="Case number"><input className={input} data-testid="f-caseNumber" value={form.caseInfo.caseNumber} onChange={(e) => setGroup('caseInfo', { caseNumber: e.target.value })} /></Field>
+          <Field label="Conviction date"><input className={input} placeholder="YYYY-MM-DD" value={form.caseInfo.convictionDate} onChange={(e) => setGroup('caseInfo', { convictionDate: e.target.value })} /></Field>
+        </div>
+        <p className={label}>Charges</p>
+        {form.caseInfo.charges.map((c, i) => (
+          <div key={i} className="grid grid-cols-[1fr_1fr_1fr_auto] gap-2 items-center mb-1">
+            <input className={input} placeholder="Code (e.g. HS)" value={c.code} onChange={(e) => updateCharge(i, { code: e.target.value })} />
+            <input className={input} placeholder="Section" value={c.section} onChange={(e) => updateCharge(i, { section: e.target.value })} />
+            <input className={input} placeholder="Type" value={c.type} onChange={(e) => updateCharge(i, { type: e.target.value })} />
+            <button type="button" onClick={() => removeCharge(i)} className="text-xs text-gray-400 hover:text-red-600 px-1">✕</button>
+          </div>
+        ))}
+        <button type="button" onClick={addCharge} className="text-xs text-blue-600 hover:text-blue-800">+ Add charge</button>
+      </Section>
+
+      <Section title="Relief (staff-selected)">
+        <Field label="Dismissal basis (Penal Code section)">
+          <select className={input} data-testid="f-dismissalBasis" value={form.relief.dismissalBasis} onChange={(e) => setGroup('relief', { dismissalBasis: e.target.value })}>
+            <option value="">Reviewer must select…</option>
+            {DISMISSAL_BASIS_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>{o.label}</option>
+            ))}
+          </select>
+        </Field>
+        <label className="flex items-center gap-1.5 text-sm text-gray-700">
+          <input type="checkbox" checked={form.relief.felonyReductionRequested} onChange={(e) => setGroup('relief', { felonyReductionRequested: e.target.checked })} />
+          Felony reduction requested
+        </label>
+      </Section>
+
+      <label className="flex items-center gap-1.5 text-sm font-medium text-gray-900">
+        <input type="checkbox" data-testid="f-staffReviewed" checked={form.staffReviewed} onChange={(e) => set({ staffReviewed: e.target.checked })} />
+        I confirm this intake was staff-reviewed (required before generation)
+      </label>
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <fieldset className="rounded-lg border border-gray-200 p-3 space-y-2">
+      <legend className="text-xs font-semibold text-gray-700 uppercase tracking-wide px-1">{title}</legend>
+      {children}
+    </fieldset>
+  );
+}
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <span className="block text-xs font-medium text-gray-600 mb-0.5">{label}</span>
+      {children}
+    </div>
+  );
+}

--- a/src/components/staff/README.md
+++ b/src/components/staff/README.md
@@ -1,0 +1,76 @@
+# Staff Document Dashboard
+
+An operational, **staff-only** dashboard for reviewing document packages created from paid
+orders and generating the official California dismissal packet (CR-180 + CR-181) from
+staff-reviewed intake.
+
+This sits on top of the document-automation core (`src/lib/documents/`) and the official
+generator added in earlier phases. It adds **no new generation logic** — it is a secure UI +
+session-authenticated API surface over the existing services.
+
+## Where things live
+
+| Path | Purpose |
+|------|---------|
+| `src/app/admin-panel/document-packages/page.tsx` | Server component. Auth gate (Payload session, admin/superadmin), then mounts the client dashboard. |
+| `src/components/staff/DocumentPackagesDashboard.tsx` | List view: filter by status / official-only, status chips, per-row check summary. |
+| `src/components/staff/OfficialPackageReview.tsx` | Detail/review panel: intake form, validation checklist, Save / Approve / Generate. |
+| `src/components/staff/constants.ts` | UI option lists (dismissal bases, supported counties, status labels) mirroring the backend closed sets. |
+| `src/app/api/staff/_session.ts` | `requireStaff()` — Payload session auth + role check for every staff API call. |
+| `src/app/api/staff/document-packages/**` | Session-authenticated list / detail / save-intake / approve / generate routes. |
+
+## Security model
+
+- **Not public.** Every page render and every API request re-checks the logged-in Payload
+  user via `payload.auth({ headers })` and requires role `admin` or `superadmin`. This is the
+  same auth that guards the Payload admin UI — no new, weaker credential is introduced.
+- The CRON_SECRET-gated routes under `src/app/api/documents/*` still exist for server-side
+  tooling and are **unchanged**. The staff dashboard uses the separate session-gated
+  `/api/staff/*` routes so a human session never needs the shared secret.
+- **No public PDF exposure.** The dashboard shows only non-PII artifact metadata (file name,
+  byte size, sample flag, timestamp). The generated PDF stays in admin-gated Payload media;
+  there is still no signed public download route (intentional — see "What remains manual").
+- **PII discipline.** The list view omits intake PII entirely. Validation reasons and the
+  audit log are short, non-PII strings. Logging uses `safeLog`; no intake data is logged or
+  sent to analytics.
+
+## Staff workflow
+
+1. **Open** `/admin-panel/document-packages` (must be signed into the admin panel as
+   admin/superadmin). Filter to **Official only** to focus on CR-180/CR-181 packages.
+2. **Open a package** to see its status, review state, and (for official packages) the
+   intake form + validation checklist.
+3. **Enter / edit the staff-reviewed intake**:
+   - **Petitioner**: full name (required), address, contact, self-represented flag.
+   - **Court**: county (required). San Bernardino / Riverside have known court addresses;
+     other counties require the court address fields to be filled manually.
+   - **Case**: case number (required), conviction date, charges.
+   - **Relief**: dismissal basis Penal Code section (**required — a reviewer must select it
+     explicitly; it is never inferred from quiz answers**), felony-reduction flag.
+   - Tick **"staff-reviewed"** to satisfy the hard gate.
+4. **Save Review** — persists the intake and re-runs validation. Missing/blocking items show
+   in the **Validation** checklist.
+5. **Approve Intake** — records the human-review approval (reviewer = the logged-in staff
+   user). Required before generation.
+6. **Generate Official Packet** — only enabled after approval. Blocked (with reasons) unless
+   the saved intake validates. **Generate Sample** stamps a SAMPLE / NOT FOR FILING
+   watermark for demos.
+7. **Review the artifact metadata** and follow the manual next steps below.
+
+## Required fields (generation will block without them)
+
+- `staffReviewed = true`
+- Petitioner full name
+- Court county
+- Case number
+- Dismissal basis (one of §§ 1203.4 / 1203.4a / 1203.41 / 1203.42 / 1203.49)
+
+## What remains manual (by design)
+
+- **Retrieving the PDF**: it lives in admin-gated Payload media. There is no public/signed
+  download route yet — a reviewer pulls it from media storage. Building a secure, audited
+  download/delivery route is a deliberate future step.
+- **Final verification**: a human verifies the filled CR-180/CR-181 before anything is filed.
+- **Delivery**: packets are left at `generated` and are **never auto-delivered** to clients.
+- **Other counties' court addresses**: only San Bernardino / Riverside are known; other
+  counties require staff to enter the court address — the system never invents one.

--- a/src/components/staff/constants.ts
+++ b/src/components/staff/constants.ts
@@ -1,0 +1,42 @@
+// UI-facing option lists for the staff document dashboard. These mirror the backend's
+// closed sets (src/lib/documents/official/forms.mjs). They are intentionally duplicated as
+// plain UI constants so the client bundle does not pull in the .mjs document core; the
+// server still re-validates every submission, so this list is convenience only.
+
+export const DISMISSAL_BASIS_OPTIONS = [
+  { value: '1203.4', label: '§ 1203.4 — Felony/misdemeanor with probation granted' },
+  { value: '1203.4a', label: '§ 1203.4a — Misdemeanor/infraction, non-probation sentence' },
+  { value: '1203.41', label: '§ 1203.41 — Felony county jail / state prison sentence' },
+  { value: '1203.42', label: '§ 1203.42 — Pre-realignment felony prison sentence' },
+  { value: '1203.49', label: '§ 1203.49 — § 647(b) human-trafficking victim' },
+] as const;
+
+export const SUPPORTED_COUNTY_OPTIONS = [
+  { value: 'san_bernardino', label: 'San Bernardino (court address known)' },
+  { value: 'riverside', label: 'Riverside (court address known)' },
+] as const;
+
+export const STATUS_LABELS: Record<string, string> = {
+  intake_needed: 'Intake Needed',
+  ready_for_review: 'Ready for Review',
+  needs_manual_review: 'Needs Manual Review',
+  generated: 'Generated',
+  delivered: 'Delivered',
+  blocked: 'Blocked',
+};
+
+export const STATUS_CHIP_CLASS: Record<string, string> = {
+  intake_needed: 'bg-gray-100 text-gray-800',
+  ready_for_review: 'bg-blue-100 text-blue-800',
+  needs_manual_review: 'bg-amber-100 text-amber-800',
+  generated: 'bg-green-100 text-green-800',
+  delivered: 'bg-emerald-100 text-emerald-800',
+  blocked: 'bg-red-100 text-red-800',
+};
+
+export const TEMPLATE_LABELS: Record<string, string> = {
+  diy_kit: 'DIY Kit',
+  expert_review: 'Expert Review',
+  full_service: 'Full Service',
+  official_ca_dismissal_packet: 'Official CA Dismissal Packet',
+};

--- a/src/lib/documents/__tests__/staff-intake.test.mjs
+++ b/src/lib/documents/__tests__/staff-intake.test.mjs
@@ -1,0 +1,155 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createPackageForSession,
+  approvePackage,
+  saveOfficialIntake,
+  generateOfficialPacket,
+  intakeFromStored,
+} from '../service-core.mjs';
+
+// Reuses the same in-memory fake-payload shape as official-service.test.mjs.
+function makeFakePayload() {
+  const store = new Map();
+  let seq = 0;
+  const get = (c) => {
+    if (!store.has(c)) store.set(c, []);
+    return store.get(c);
+  };
+  return {
+    async find({ collection, where }) {
+      const docs = get(collection);
+      if (where?.sourceSessionId?.equals !== undefined) {
+        return { docs: docs.filter((d) => d.sourceSessionId === where.sourceSessionId.equals) };
+      }
+      return { docs };
+    },
+    async create({ collection, data }) {
+      const doc = { id: ++seq, ...data };
+      get(collection).push(doc);
+      return doc;
+    },
+    async findByID({ collection, id }) {
+      return get(collection).find((d) => d.id === id);
+    },
+    async update({ collection, id, data }) {
+      const doc = get(collection).find((d) => d.id === id);
+      Object.assign(doc, data);
+      return doc;
+    },
+  };
+}
+
+// Mirrors the shape the staff dashboard posts (canonical OfficialIntake), passed through
+// service.saveOfficialIntake which stores it under officialIntake.caseInfo.
+const fullIntake = () => ({
+  staffReviewed: true,
+  selfRepresented: true,
+  petitioner: { fullName: 'DOE, JANE', email: 'jane@example.com', phone: '9095551234' },
+  court: { county: 'san_bernardino' },
+  case: { caseNumber: 'FSB-2020-0001', convictionDate: '2019-03-01', charges: [{ code: 'PC', section: '459', type: 'felony' }] },
+  relief: { dismissalBasis: '1203.4' },
+});
+
+async function newOfficial(payload, sessionId = 'manual:staff-1') {
+  const { id } = await createPackageForSession(payload, {
+    sourceSessionId: sessionId,
+    templateKey: 'official_ca_dismissal_packet',
+  });
+  return id;
+}
+
+test('saveOfficialIntake persists intake and reports valid when complete', async () => {
+  const payload = makeFakePayload();
+  const id = await newOfficial(payload);
+  const res = await saveOfficialIntake(payload, { id, actor: 'staff@x.com', intake: fullIntake() });
+
+  assert.equal(res.validation.ok, true);
+  assert.deepEqual(res.validation.reasons, []);
+
+  const doc = await payload.findByID({ collection: 'document-packages', id });
+  assert.equal(doc.officialIntake.staffReviewed, true);
+  // Stored under caseInfo (Payload-friendly key), not `case`.
+  assert.equal(doc.officialIntake.caseInfo.caseNumber, 'FSB-2020-0001');
+  assert.equal(doc.officialIntake.savedBy, 'staff@x.com');
+  assert.equal(doc.validation.ok, true);
+  // Audit trail must record the save without leaking PII into the detail string.
+  const last = doc.auditLog[doc.auditLog.length - 1];
+  assert.equal(last.action, 'intake_saved');
+  assert.ok(!last.detail.includes('FSB-2020-0001'));
+});
+
+test('saveOfficialIntake reports validation issues for incomplete intake without throwing', async () => {
+  const payload = makeFakePayload();
+  const id = await newOfficial(payload, 'manual:staff-2');
+  const incomplete = fullIntake();
+  incomplete.staffReviewed = false;
+  incomplete.relief.dismissalBasis = '';
+
+  const res = await saveOfficialIntake(payload, { id, actor: 'staff@x.com', intake: incomplete });
+  assert.equal(res.validation.ok, false);
+  assert.ok(res.validation.reasons.length >= 2);
+  // Reasons are short non-PII strings.
+  for (const r of res.validation.reasons) {
+    assert.equal(typeof r, 'string');
+    assert.ok(!r.includes('FSB-2020-0001'));
+  }
+});
+
+test('generate uses saved intake when no intake arg is passed (dashboard path)', async () => {
+  const payload = makeFakePayload();
+  const id = await newOfficial(payload, 'manual:staff-3');
+  await saveOfficialIntake(payload, { id, actor: 'staff@x.com', intake: fullIntake() });
+  await approvePackage(payload, { id, actor: 'staff@x.com' });
+
+  // No `intake` passed — must fall back to the stored officialIntake.
+  const res = await generateOfficialPacket(payload, { id, actor: 'staff@x.com' });
+  assert.equal(res.status, 'generated');
+  assert.ok(!res.blocked);
+
+  const doc = await payload.findByID({ collection: 'document-packages', id });
+  assert.ok(doc.generatedFile);
+  assert.ok(doc.generatedArtifact.fileName.endsWith('.pdf'));
+  assert.equal(doc.generatedArtifact.sample, false);
+  assert.ok(doc.generatedArtifact.byteSize > 0);
+});
+
+test('generate stays blocked when saved intake is incomplete', async () => {
+  const payload = makeFakePayload();
+  const id = await newOfficial(payload, 'manual:staff-4');
+  const incomplete = fullIntake();
+  incomplete.relief.dismissalBasis = '';
+  await saveOfficialIntake(payload, { id, actor: 'staff@x.com', intake: incomplete });
+  await approvePackage(payload, { id, actor: 'staff@x.com' });
+
+  const res = await generateOfficialPacket(payload, { id, actor: 'staff@x.com' });
+  assert.equal(res.blocked, true);
+  assert.ok(res.reasons.length >= 1);
+
+  const doc = await payload.findByID({ collection: 'document-packages', id });
+  assert.ok(!doc.generatedFile);
+});
+
+test('generate stays blocked before review approval even with valid saved intake', async () => {
+  const payload = makeFakePayload();
+  const id = await newOfficial(payload, 'manual:staff-5');
+  await saveOfficialIntake(payload, { id, actor: 'staff@x.com', intake: fullIntake() });
+
+  const res = await generateOfficialPacket(payload, { id, actor: 'staff@x.com' });
+  assert.equal(res.blocked, true);
+  assert.match(res.reasons[0], /review required/i);
+});
+
+test('intakeFromStored maps caseInfo back to canonical case shape', () => {
+  const canonical = intakeFromStored({
+    staffReviewed: true,
+    selfRepresented: false,
+    petitioner: { fullName: 'DOE, JANE' },
+    court: { county: 'riverside' },
+    caseInfo: { caseNumber: 'X-1', charges: [{ code: 'PC', section: '459', type: 'felony' }] },
+    relief: { dismissalBasis: '1203.4' },
+  });
+  assert.equal(canonical.case.caseNumber, 'X-1');
+  assert.equal(canonical.case.charges[0].section, '459');
+  assert.equal(canonical.relief.dismissalBasis, '1203.4');
+});

--- a/src/lib/documents/service-core.mjs
+++ b/src/lib/documents/service-core.mjs
@@ -78,6 +78,113 @@ async function loadPackage(payload, id) {
   return doc;
 }
 
+// The collection stores the intake under `officialIntake` with `caseInfo` (the word `case`
+// is awkward as a Payload field name). The validator/mapping layer expects the canonical
+// OfficialIntake shape with a `case` key. This adapts the stored shape into that canonical
+// shape without copying anything extra.
+export function intakeFromStored(stored) {
+  if (!stored || typeof stored !== 'object') return undefined;
+  const caseInfo = stored.caseInfo || {};
+  return {
+    staffReviewed: stored.staffReviewed === true,
+    selfRepresented: stored.selfRepresented === true,
+    petitioner: { ...(stored.petitioner || {}) },
+    court: { ...(stored.court || {}) },
+    case: {
+      caseNumber: caseInfo.caseNumber,
+      convictionDate: caseInfo.convictionDate,
+      charges: Array.isArray(caseInfo.charges)
+        ? caseInfo.charges.map((c) => ({ code: c.code, section: c.section, type: c.type }))
+        : undefined,
+    },
+    relief: { ...(stored.relief || {}) },
+  };
+}
+
+// Maps a canonical OfficialIntake (as posted by the staff dashboard) into the stored
+// collection shape. Drops unknown keys; never persists anything beyond the known fields.
+function intakeToStored(intake, { savedBy } = {}) {
+  const c = intake.case || {};
+  return {
+    staffReviewed: intake.staffReviewed === true,
+    selfRepresented: intake.selfRepresented === true,
+    petitioner: {
+      fullName: intake.petitioner?.fullName,
+      street: intake.petitioner?.street,
+      city: intake.petitioner?.city,
+      state: intake.petitioner?.state,
+      zip: intake.petitioner?.zip,
+      phone: intake.petitioner?.phone,
+      email: intake.petitioner?.email,
+    },
+    court: {
+      county: intake.court?.county,
+      courtName: intake.court?.courtName,
+      courtStreet: intake.court?.courtStreet,
+      courtCityZip: intake.court?.courtCityZip,
+    },
+    caseInfo: {
+      caseNumber: c.caseNumber,
+      convictionDate: c.convictionDate,
+      charges: Array.isArray(c.charges)
+        ? c.charges.map((ch) => ({ code: ch.code, section: ch.section, type: ch.type }))
+        : [],
+    },
+    relief: {
+      dismissalBasis: intake.relief?.dismissalBasis,
+      felonyReductionRequested: intake.relief?.felonyReductionRequested === true,
+    },
+    savedBy: savedBy || 'staff',
+    savedAt: new Date().toISOString(),
+  };
+}
+
+// Persists staff-reviewed official intake on the package and records the latest validation
+// outcome (non-PII reasons only). Does NOT change the package status or generate anything —
+// it is a pure save so staff can iterate on the form. Only valid for official packages.
+//
+// Returns { validation: { ok, reasons } } so the UI can show the missing-field checklist.
+export async function saveOfficialIntake(payload, args) {
+  const pkg = await loadPackage(payload, args.id);
+  if (!isOfficialTemplate(pkg.templateKey)) {
+    throw new Error('Package is not an official_ca_dismissal_packet');
+  }
+
+  const stored = intakeToStored(args.intake || {}, { savedBy: args.actor });
+  const canonical = intakeFromStored(stored);
+  const validation = validateOfficialIntake(canonical);
+
+  const entry = buildAuditEntry({
+    action: 'intake_saved',
+    fromStatus: pkg.status,
+    toStatus: pkg.status,
+    actor: args.actor || 'staff',
+    detail: validation.ok
+      ? 'Official intake saved; passes validation'
+      : `Official intake saved; ${validation.reasons.length} validation issue(s)`,
+  });
+
+  await payload.update({
+    collection: COLLECTION,
+    id: args.id,
+    data: {
+      officialIntake: stored,
+      validation: {
+        ok: validation.ok === true,
+        reasons: (validation.ok ? [] : validation.reasons).map((reason) => ({ reason })),
+        checkedAt: new Date().toISOString(),
+      },
+      auditLog: [...(pkg.auditLog || []), entry],
+    },
+  });
+  safeLog('official.intake_saved', {
+    id: String(args.id),
+    ok: validation.ok === true,
+    issues: validation.ok ? 0 : validation.reasons.length,
+  });
+  return { validation: { ok: validation.ok === true, reasons: validation.ok ? [] : validation.reasons } };
+}
+
 export async function approvePackage(payload, args) {
   const pkg = await loadPackage(payload, args.id);
   const { status, entry } = transition({
@@ -209,9 +316,12 @@ export async function generateOfficialPacket(payload, args) {
     return { status, blocked: true, reasons: ['Human review required before generation'] };
   }
 
-  // Validate the staff-reviewed intake. Failure => needs_manual_review / blocked with
-  // non-PII reasons. We log only the count and the short rule strings (never the data).
-  const validation = validateOfficialIntake(args.intake);
+  // Validate the staff-reviewed intake. The caller may pass `intake` explicitly (CRON_SECRET
+  // tooling) or rely on the intake the staff dashboard already saved on the package. Failure
+  // => needs_manual_review / blocked with non-PII reasons. We log only the count and the
+  // short rule strings (never the data).
+  const intake = args.intake || intakeFromStored(pkg.officialIntake);
+  const validation = validateOfficialIntake(intake);
   if (!validation.ok) {
     const { status, entry } = transition({
       from: pkg.status,
@@ -231,13 +341,14 @@ export async function generateOfficialPacket(payload, args) {
   const { buildOfficialDismissalPacket } = await import('./official/fill.mjs');
   const pdf = await buildOfficialDismissalPacket(validation.data, { sample: args.sample === true });
 
+  const artifactName = `ca-dismissal-${pkg.sourceSessionId}.pdf`.replace(/[^a-zA-Z0-9.-]/g, '_');
   const media = await payload.create({
     collection: 'media',
     data: { alt: 'Official CA dismissal packet (CR-180 + CR-181)' },
     file: {
       data: Buffer.from(pdf),
       mimetype: 'application/pdf',
-      name: `ca-dismissal-${pkg.sourceSessionId}.pdf`.replace(/[^a-zA-Z0-9.-]/g, '_'),
+      name: artifactName,
       size: pdf.byteLength,
     },
   });
@@ -273,6 +384,12 @@ export async function generateOfficialPacket(payload, args) {
     data: {
       status,
       generatedFile: media.id,
+      generatedArtifact: {
+        fileName: artifactName,
+        byteSize: pdf.byteLength,
+        sample: args.sample === true,
+        generatedAt: new Date().toISOString(),
+      },
       auditLog,
     },
   });

--- a/src/lib/documents/service.ts
+++ b/src/lib/documents/service.ts
@@ -44,13 +44,29 @@ export function generatePackage(
   return core.generatePackage(payload, args);
 }
 
+// Persists staff-reviewed official intake on a package and records the latest validation
+// outcome (non-PII reasons). Does not change status or generate; lets staff iterate on the
+// form before approving/generating. Returns the validation result for the UI checklist.
+export function saveOfficialIntake(
+  payload: Payload,
+  args: { id: string | number; actor?: string; intake: OfficialIntake },
+): Promise<{ validation: { ok: boolean; reasons: string[] } }> {
+  return core.saveOfficialIntake(payload, args);
+}
+
+// Adapts the collection-stored intake shape (with `caseInfo`) into the canonical
+// OfficialIntake shape used by validation/mapping.
+export function intakeFromStored(stored: unknown): OfficialIntake | undefined {
+  return core.intakeFromStored(stored);
+}
+
 // Generates the official CA dismissal packet (filled CR-180 + draft CR-181) from
 // staff-reviewed intake. Blocked (needs_manual_review / blocked) with non-PII `reasons` if
 // review is not approved or required intake data is missing. `sample: true` watermarks the
 // output SAMPLE / NOT FOR FILING (demos/tests only).
 export function generateOfficialPacket(
   payload: Payload,
-  args: { id: string | number; actor?: string; intake: OfficialIntake; sample?: boolean },
+  args: { id: string | number; actor?: string; intake?: OfficialIntake; sample?: boolean },
 ): Promise<{ status: DocumentStatus; blocked?: boolean; reasons?: string[] }> {
   return core.generateOfficialPacket(payload, args);
 }


### PR DESCRIPTION
## Summary

Adds a secure, **staff-only** dashboard + session-authenticated API surface for reviewing document packages created from paid orders and generating the official California dismissal packet (CR-180 + CR-181). This sits on top of the existing document-automation core and official generator (PRs #8, #9) and introduces **no new generation logic** — it is a UI + auth layer over existing services.

### What staff can do
- View document packages from paid orders, filtered by status / official-only, with status chips and a per-row check summary (no intake PII in the list).
- Open a package to review its status, validation state, and (for official packages) the intake form + validation checklist.
- Enter/edit the **staff-reviewed** OfficialIntake (petitioner, court, case, relief). The dismissal-basis Penal Code section must be **explicitly selected by a reviewer — it is never inferred from quiz answers**.
- Save the intake (re-runs validation, surfaces blocking reasons), approve the review, then generate the official packet (or a SAMPLE watermarked packet).
- See generated-artifact metadata (file name, byte size, sample flag, timestamp) and the manual next steps.

### Security / compliance
- **Not public.** Every page render and API request re-checks the logged-in Payload user (`payload.auth({ headers })`) and requires role `admin`/`superadmin` — same auth as the Payload admin UI, no new weaker credential. Dashboard lives at `/admin-panel/document-packages`; APIs at `/api/staff/*` (session-gated, separate from the unchanged CRON_SECRET `/api/documents/*` internal routes).
- **No public PDF exposure.** Only non-PII artifact metadata is shown; the PDF stays in admin-gated Payload media. No signed/public download route (intentionally left as a future step).
- **PII discipline.** List view omits intake PII; validation reasons and audit log are short non-PII strings; logging uses `safeLog`; no intake data is logged or sent to analytics.
- **Legal gates preserved.** Generation is blocked unless the intake is staff-reviewed, validates, and the review is approved. Packets are never auto-delivered.

## Files changed
- `src/collections/DocumentPackages.ts` — admin-gated `officialIntake`, `validation`, `generatedArtifact` field groups (conditioned on the official template).
- `src/lib/documents/service-core.mjs` / `service.ts` — `saveOfficialIntake`, `intakeFromStored`; generation falls back to the saved intake and records artifact metadata.
- `src/app/api/staff/**` — `requireStaff()` session guard + list / detail / save-intake / approve / generate routes; serializers and untrusted-body parsing.
- `src/app/admin-panel/document-packages/page.tsx` — server component auth gate.
- `src/components/staff/**` — dashboard list, official review panel, UI constants, README.
- `src/lib/documents/__tests__/staff-intake.test.mjs` — coverage for save/validate/generate gating + PII-leak assertions.

## Testing
- `node --test src/lib/documents/__tests__/` — 43/50 pass. The 7 failures are all the pre-existing `Cannot find module './api/index'` from an incompletely-extracted `pdf-lib` in this sandbox (6 pre-existing generation tests + 1 new generation test); they are environmental, not logic. All 5 new non-generation tests pass.
- `npm install`, `tsc --noEmit`, and `next build` could not run: the sandbox disk is full (ENOSPC), so `node_modules`/`typescript` are incomplete. No production code was altered to work around this. Manual TypeScript review performed instead.
- No real forms/purchases submitted; tests use in-memory fake-payload + fake intake data only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)