### PR TITLE
Fix: restrict Leads collection access to admin/superadmin

### DIFF
--- a/src/collections/Leads.ts
+++ b/src/collections/Leads.ts
@@ -7,8 +7,20 @@ import {
 
 const Leads: CollectionConfig = {
   slug: 'leads',
-  admin: { 
-    useAsTitle: 'email', 
+  // Leads hold customer PII (name, email, phone, address, conviction type). Without an
+  // explicit access block Payload falls back to "any authenticated user", which would let
+  // the default `user`/`manager` roles read, edit, and delete every lead through the REST
+  // and GraphQL APIs. Restrict to admin/superadmin, matching Orders/Analytics. Frontend
+  // lead capture goes through the Local API (`/api/lead`, overrideAccess), so `create`
+  // stays open and public capture is unaffected.
+  access: {
+    read: ({ req }) => req.user?.role === 'admin' || req.user?.role === 'superadmin',
+    create: () => true,
+    update: ({ req }) => req.user?.role === 'admin' || req.user?.role === 'superadmin',
+    delete: ({ req }) => req.user?.role === 'superadmin',
+  },
+  admin: {
+    useAsTitle: 'email',
     defaultColumns: [
       'first',
       'last', 


### PR DESCRIPTION
## Summary

Backend/CRM/database audit pass on the production Wipe That Record app (post PR #10 staff dashboard). This PR lands one contained, clearly-safe security fix uncovered during the audit; the remaining findings are documented below for follow-up because they need coordinated changes / product decisions.

### Fix in this PR: Leads collection had no access control

The `Leads` collection stores customer PII (name, email, phone, street/city/state/zip, conviction type, lead scoring) but shipped **without an `access` block**. Every sibling data collection (`Orders`, `Analytics`, `Products`, `DocumentPackages`, `Users`) restricts access by role; `Leads` did not.

With no access block, Payload falls back to its default ("any authenticated user"). Since the `Users` collection defaults new accounts to role `user` and also has a `manager` role, **any authenticated non-admin user could read, edit, and delete every lead** — including PII — through the Payload REST (`/api/payload/leads`, `(payload)/api/[...slug]`) and GraphQL APIs.

The fix mirrors the `Orders` pattern exactly:
- `read` / `update` -> `admin` or `superadmin`
- `delete` -> `superadmin`
- `create` -> open (public lead capture goes through the Local API at `/api/lead`, which uses `overrideAccess`, so this is unaffected)

This is defense-in-depth on the Payload REST/GraphQL surface and does not change any Local-API path.

## Testing

- `node --test src/lib/documents/__tests__/` -> **55/55 pass** (pdf-lib installed in an isolated dir due to sandbox disk limits; the 7 "failures" seen before install were purely `ERR_MODULE_NOT_FOUND` for `pdf-lib`, not code defects).
- Change is isolated to the `Leads` config and is a structural copy of the already-shipping `Orders`/`Analytics` access blocks.
- `tsc --noEmit` / `next build` could **not** be run in this sandbox: installing the full Payload + Next dependency tree exceeded available disk (`ENOSPC`, ~200 MB free). Validate in CI.

## Audit notes (NOT fixed here — need follow-up)

**High risk — unauthenticated admin surface & PII routes (pre-existing, not from PR #10):**
- `src/app/admin-panel/page.tsx` is a client page with **no auth gate**; `src/app/admin-panel/layout.tsx` is a passthrough. `middleware.ts` redirects `/admin`, `/admin-dashboard`, `/marketing-dashboard` -> `/admin-panel`.
- Several custom routes read PII via the Local API (which bypasses collection access) with **no auth guard** and are called client-side from the dashboards: `/api/leads`, `/api/leads/[id]`, `/api/orders`, `/api/orders/[id]`, `/api/customers`, `/api/admin-stats`, `/api/dashboard-metrics`, `/api/analytics`.
- Recommended remediation: gate `/admin-panel` behind an authenticated session, and add a shared staff guard (like the existing `requireStaff` in `src/app/api/staff/_session.ts`) to the custom data routes. Not done here because it spans ~15 routes and depends on the intended admin auth model (Payload session vs. the Supabase client the page imports) — a wrong guard could break the production dashboard.
- Also review `/api/init-admin`, `/api/init-db`, `/api/init-simple`, `/api/unlock-admin`, `/api/test-db`, `/api/env-check` for public exposure.

**Verified healthy (in scope):**
- Stripe webhook (`/api/webhook`): signature-validated; document-package creation is idempotent on the Stripe session id (`createPackageForSession` dedups + handles the unique-index race); failures are swallowed so they never 500 the webhook.
- Document automation: `/api/documents/*` is CRON_SECRET-gated (`authorizeInternal`); `/api/staff/*` is session + admin/superadmin-gated (`requireStaff`). Official CR-180/CR-181 generation requires both the human-review gate AND validated staff-reviewed intake, and never derives legal choices from marketing data.
- `DocumentPackages` collection deliberately omits case PII and is admin-gated; `sourceSessionId` is unique-indexed.
- `payload.config.ts` DB handling: `DATABASE_URI` is validated as a real `mongodb(+srv)://` string, otherwise Payload boots without a DB connection to avoid build-time crashes.

**Minor:**
- `/api/checkout` sets `metadata.product` but not `metadata.type`, so the webhook's `type`-based branch falls through to legacy handling and won't create a document package for that route (the DIY/upgrade routes set `type` correctly).
- Webhook creates a new lead per `checkout.session.completed` without deduping on session id (document package is deduped, leads are not) — retries could duplicate lead rows.
- `payload.config.ts` `secret: process.env.PAYLOAD_SECRET || ''` falls back to an empty secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)