### PR TITLE
Security: gate /admin-panel, CRM/PII APIs, and setup routes behind staff auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test": "node --test src/lib/documents/__tests__/",
+    "test": "node --test src/lib/documents/__tests__/ src/lib/auth/__tests__/",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/payload.config.ts
+++ b/payload.config.ts
@@ -184,11 +184,13 @@ export default buildConfig({
   cors: [
     'http://localhost:3000',
     'http://localhost:3001',
-    'https://your-domain.com', // production
+    'https://www.wipethatrecord.com',
+    'https://wipethatrecord.com',
   ],
   csrf: [
     'http://localhost:3000',
     'http://localhost:3001',
-    'https://your-domain.com',
+    'https://www.wipethatrecord.com',
+    'https://wipethatrecord.com',
   ],
 }) 

--- a/src/app/admin-panel/layout.tsx
+++ b/src/app/admin-panel/layout.tsx
@@ -1,7 +1,82 @@
-export default function AdminLayout({
+import React from 'react'
+import Link from 'next/link'
+import { headers as nextHeaders } from 'next/headers'
+import { getPayload } from 'payload'
+import config from '@payload-config'
+import { isStaffRole } from '@/lib/auth/roles.mjs'
+
+export const dynamic = 'force-dynamic'
+
+// Server-side auth gate for the custom operational dashboard. /admin-panel renders lead,
+// order, and customer PII, so it must never be served to an unauthenticated visitor.
+// We authenticate the logged-in Payload user via the session cookie and require an
+// admin/superadmin role — the same model used by the staff API routes
+// (src/app/api/staff/_session.ts) and the Payload admin UI. When the visitor is not an
+// authorized staff member we render a "sign-in required" screen and never render the
+// dashboard children (which fetch data on mount).
+async function getStaffUser() {
+  try {
+    const payload = await getPayload({ config })
+    const requestHeaders = await nextHeaders()
+    const { user } = await payload.auth({ headers: requestHeaders })
+    if (user && isStaffRole((user as { role?: string }).role)) {
+      return user
+    }
+  } catch {
+    // Fall through to the sign-in-required screen on any auth/service error.
+  }
+  return null
+}
+
+function SignInRequired() {
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: '#0f172a',
+        color: '#e2e8f0',
+        fontFamily: 'system-ui, sans-serif',
+        padding: '1.5rem',
+      }}
+    >
+      <div style={{ maxWidth: 420, textAlign: 'center' }}>
+        <h1 style={{ fontSize: '1.5rem', fontWeight: 700, marginBottom: '0.75rem' }}>
+          Staff sign-in required
+        </h1>
+        <p style={{ color: '#94a3b8', marginBottom: '1.5rem' }}>
+          The admin panel is restricted to authorized staff. Please sign in with an
+          administrator account to continue.
+        </p>
+        <Link
+          href="/admin"
+          style={{
+            display: 'inline-block',
+            background: '#2563eb',
+            color: '#fff',
+            padding: '0.6rem 1.25rem',
+            borderRadius: '0.5rem',
+            fontWeight: 600,
+            textDecoration: 'none',
+          }}
+        >
+          Go to sign in
+        </Link>
+      </div>
+    </div>
+  )
+}
+
+export default async function AdminLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
+  const user = await getStaffUser()
+  if (!user) {
+    return <SignInRequired />
+  }
   return <>{children}</>
 }

--- a/src/app/api/admin-stats/route.ts
+++ b/src/app/api/admin-stats/route.ts
@@ -1,10 +1,13 @@
-import { NextResponse } from 'next/server';
-import { getPayload } from 'payload';
-import config from '../../../../payload.config';
+import { NextRequest, NextResponse } from 'next/server';
+import { requireStaff } from '@/app/api/staff/_session';
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  // Aggregated business/customer stats — staff-only (admin/superadmin).
+  const auth = await requireStaff(request);
+  if ('response' in auth) return auth.response;
+  const { payload } = auth.session;
+
   try {
-    const payload = await getPayload({ config });
 
     // Get real product stats
     const products = await payload.find({

--- a/src/app/api/analytics/route.ts
+++ b/src/app/api/analytics/route.ts
@@ -1,13 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getPayload } from 'payload';
-import config from '../../../../payload.config';
+import { requireStaff } from '@/app/api/staff/_session';
 
 export async function GET(req: NextRequest) {
+  // Aggregates over all leads (PII source) — staff-only (admin/superadmin).
+  const auth = await requireStaff(req);
+  if ('response' in auth) return auth.response;
+  const { payload } = auth.session;
+
   try {
     console.log('📊 Fetching comprehensive analytics data...');
-    
-    const payload = await getPayload({ config });
-    
+
     // Get all leads for analysis
     const allLeads = await payload.find({
       collection: 'leads',

--- a/src/app/api/customers/route.ts
+++ b/src/app/api/customers/route.ts
@@ -1,6 +1,11 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { requireStaff } from '@/app/api/staff/_session';
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  // Customer directory (names, emails, phones) — staff-only (admin/superadmin).
+  const auth = await requireStaff(request);
+  if ('response' in auth) return auth.response;
+
   try {
     // Mock customer data
     const customers = [

--- a/src/app/api/dashboard-metrics/route.ts
+++ b/src/app/api/dashboard-metrics/route.ts
@@ -1,11 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getPayload } from 'payload';
-import config from '../../../../payload.config';
+import { requireStaff } from '@/app/api/staff/_session';
 
 export async function GET(req: NextRequest) {
+  // Aggregated revenue/lead metrics — staff-only (admin/superadmin).
+  const auth = await requireStaff(req);
+  if ('response' in auth) return auth.response;
+  const { payload } = auth.session;
+
   try {
-    const payload = await getPayload({ config });
-    
+
     // Date calculations
     const now = new Date();
     const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());

--- a/src/app/api/documents/_auth.ts
+++ b/src/app/api/documents/_auth.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { isValidBearer } from '@/lib/auth/roles.mjs';
 
 // Internal/admin auth for the document endpoints, mirroring the cron routes
 // (src/app/api/cron/*). Staff drive these via tooling that holds CRON_SECRET; humans
@@ -13,7 +14,7 @@ export function authorizeInternal(request: NextRequest): NextResponse | null {
     );
   }
   const authHeader = request.headers.get('authorization');
-  if (authHeader !== `Bearer ${secret}`) {
+  if (!isValidBearer(authHeader, secret)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
   return null;

--- a/src/app/api/env-check/route.ts
+++ b/src/app/api/env-check/route.ts
@@ -1,6 +1,11 @@
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
+import { authorizeInternal } from '@/app/api/documents/_auth'
 
-export async function GET() {
+export async function GET(req: NextRequest) {
+  // Leaks env-var presence and secret prefixes — must never be public. Requires Bearer CRON_SECRET.
+  const unauthorized = authorizeInternal(req)
+  if (unauthorized) return unauthorized
+
   try {
     console.log('🔍 Environment check requested')
     

--- a/src/app/api/init-admin/route.ts
+++ b/src/app/api/init-admin/route.ts
@@ -1,8 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getPayload } from 'payload';
 import config from '../../../../payload.config';
+import { authorizeInternal } from '@/app/api/documents/_auth';
 
 export async function POST(req: NextRequest) {
+  // Creates/promotes a superadmin — must never be public. Requires Bearer CRON_SECRET.
+  const unauthorized = authorizeInternal(req);
+  if (unauthorized) return unauthorized;
+
   try {
     console.log('🔄 Initializing admin user...');
     

--- a/src/app/api/init-db/route.ts
+++ b/src/app/api/init-db/route.ts
@@ -1,7 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 import payload from 'payload';
+import { authorizeInternal } from '@/app/api/documents/_auth';
 
 export async function POST(req: NextRequest) {
+  // Writes/seeds the database — must never be public. Requires Bearer CRON_SECRET.
+  const unauthorized = authorizeInternal(req);
+  if (unauthorized) return unauthorized;
+
   try {
     console.log('🔍 Initializing database...');
     

--- a/src/app/api/init-simple/route.ts
+++ b/src/app/api/init-simple/route.ts
@@ -1,7 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 import payload from 'payload';
+import { authorizeInternal } from '@/app/api/documents/_auth';
 
 export async function POST(req: NextRequest) {
+  // Writes test records to the database — must never be public. Requires Bearer CRON_SECRET.
+  const unauthorized = authorizeInternal(req);
+  if (unauthorized) return unauthorized;
+
   try {
     console.log('🔍 Simple database initialization...');
     

--- a/src/app/api/leads/[id]/route.ts
+++ b/src/app/api/leads/[id]/route.ts
@@ -1,11 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getPayload } from 'payload';
-import config from '../../../../../payload.config';
+import { requireStaff } from '@/app/api/staff/_session';
 
 export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  // Mutates lead records — staff-only (admin/superadmin).
+  const auth = await requireStaff(request);
+  if ('response' in auth) return auth.response;
+  const { payload } = auth.session;
+
   try {
     const { id } = await params;
     const { conversionStage } = await request.json();
@@ -13,7 +17,6 @@ export async function PATCH(
       return NextResponse.json({ success: false, error: 'conversionStage required' }, { status: 400 });
     }
 
-    const payload = await getPayload({ config });
     const updated = await payload.update({ collection: 'leads', id, data: { conversionStage } });
     return NextResponse.json({ success: true, data: updated });
   } catch (error) {

--- a/src/app/api/leads/route.ts
+++ b/src/app/api/leads/route.ts
@@ -1,14 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getPayload } from 'payload';
-import config from '../../../../payload.config';
+import { requireStaff } from '@/app/api/staff/_session';
 
 export async function GET(request: NextRequest) {
+  // Returns lead PII — staff-only (admin/superadmin).
+  const auth = await requireStaff(request);
+  if ('response' in auth) return auth.response;
+  const { payload } = auth.session;
+
   try {
     const { searchParams } = new URL(request.url);
     const stage = searchParams.get('stage') || 'lead';
     const limit = parseInt(searchParams.get('limit') || '100');
 
-    const payload = await getPayload({ config });
 
     const leads = await payload.find({
       collection: 'leads',

--- a/src/app/api/orders/[id]/route.ts
+++ b/src/app/api/orders/[id]/route.ts
@@ -1,17 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getPayload } from 'payload';
-import config from '@payload-config';
+import { requireStaff } from '@/app/api/staff/_session';
 
 // PATCH /api/orders/[id] - Update order status and handle actions
 export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  // Mutates orders — staff-only (admin/superadmin).
+  const auth = await requireStaff(request);
+  if ('response' in auth) return auth.response;
+  const { payload } = auth.session;
+
   try {
     const { id } = await params;
     const { action, status, ...updateData } = await request.json();
-    
-    const payload = await getPayload({ config });
 
     // Map actions to statuses
     let newStatus = status;
@@ -102,9 +104,13 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  // Returns order + customer PII — staff-only (admin/superadmin).
+  const auth = await requireStaff(request);
+  if ('response' in auth) return auth.response;
+  const { payload } = auth.session;
+
   try {
     const { id } = await params;
-    const payload = await getPayload({ config });
 
     const order = await payload.findByID({
       collection: 'orders',

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -1,9 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getPayload } from 'payload';
-import config from '../../../../payload.config';
+import { requireStaff } from '@/app/api/staff/_session';
 
 // GET /api/orders - list orders with filtering & pagination
 export async function GET(request: NextRequest) {
+  // Returns order + customer PII — staff-only (admin/superadmin).
+  const auth = await requireStaff(request);
+  if ('response' in auth) return auth.response;
+  const { payload } = auth.session;
+
   try {
     const { searchParams } = new URL(request.url);
     const page = parseInt(searchParams.get('page') || '1');
@@ -28,7 +32,6 @@ export async function GET(request: NextRequest) {
       where.status = { equals: status };
     }
 
-    const payload = await getPayload({ config });
     const orders = await payload.find({
       collection: 'orders',
       where: Object.keys(where).length ? where : undefined,

--- a/src/app/api/staff/_session.ts
+++ b/src/app/api/staff/_session.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getPayload } from 'payload';
 import config from '@payload-config';
 import type { Payload } from 'payload';
+import { isStaffRole } from '@/lib/auth/roles.mjs';
 
 // Staff-session authorization for the staff dashboard endpoints.
 //
@@ -17,8 +18,6 @@ export interface StaffSession {
   user: { id: string | number; email?: string; role?: string };
   actor: string;
 }
-
-const STAFF_ROLES: StaffRole[] = ['admin', 'superadmin'];
 
 // Resolves and authorizes the staff session. Returns either an error `response` to return
 // immediately, or the authenticated `session`. Errors are intentionally terse (no internal
@@ -44,7 +43,7 @@ export async function requireStaff(
   if (!user) {
     return { response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) };
   }
-  if (!STAFF_ROLES.includes(user.role)) {
+  if (!isStaffRole(user.role)) {
     return { response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) };
   }
 

--- a/src/app/api/test-db/route.ts
+++ b/src/app/api/test-db/route.ts
@@ -1,7 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 import payload from 'payload';
+import { authorizeInternal } from '@/app/api/documents/_auth';
 
 export async function GET(req: NextRequest) {
+  // Probes DB connectivity and record counts — must never be public. Requires Bearer CRON_SECRET.
+  const unauthorized = authorizeInternal(req);
+  if (unauthorized) return unauthorized;
+
   try {
     console.log('🔍 Testing database connection...');
     

--- a/src/app/api/unlock-admin/route.ts
+++ b/src/app/api/unlock-admin/route.ts
@@ -1,8 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getPayload } from 'payload';
 import config from '../../../../payload.config';
+import { authorizeInternal } from '@/app/api/documents/_auth';
 
 export async function POST(req: NextRequest) {
+  // Resets admin login-attempt lockout (brute-force protection) — must never be public.
+  // Requires Bearer CRON_SECRET.
+  const unauthorized = authorizeInternal(req);
+  if (unauthorized) return unauthorized;
+
   try {
     const payload = await getPayload({ config });
     

--- a/src/collections/Leads.ts
+++ b/src/collections/Leads.ts
@@ -1,14 +1,27 @@
 import { CollectionConfig } from 'payload';
-import { 
-  sendDiyConfirmationEmail, 
-  sendReviewConfirmationEmail, 
-  sendFullServiceConfirmationEmail 
+import {
+  sendDiyConfirmationEmail,
+  sendReviewConfirmationEmail,
+  sendFullServiceConfirmationEmail
 } from '@/lib/email';
+import { isStaffRole, isSuperadmin } from '@/lib/auth/roles.mjs';
 
 const Leads: CollectionConfig = {
   slug: 'leads',
-  admin: { 
-    useAsTitle: 'email', 
+  // Leads hold customer PII (name, email, phone, address, conviction type). Without an
+  // explicit access block Payload falls back to "any authenticated user", which would let
+  // the default `user`/`manager` roles read, edit, and delete every lead through the REST
+  // and GraphQL APIs. Restrict to admin/superadmin, matching Orders/Analytics. Frontend
+  // lead capture goes through the Local API (`/api/lead`, overrideAccess), so `create`
+  // stays open and public capture is unaffected.
+  access: {
+    read: ({ req }) => isStaffRole(req.user?.role),
+    create: () => true,
+    update: ({ req }) => isStaffRole(req.user?.role),
+    delete: ({ req }) => isSuperadmin(req.user?.role),
+  },
+  admin: {
+    useAsTitle: 'email',
     defaultColumns: [
       'first',
       'last', 

--- a/src/lib/auth/__tests__/roles.test.mjs
+++ b/src/lib/auth/__tests__/roles.test.mjs
@@ -1,0 +1,43 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { isStaffRole, isSuperadmin, isValidBearer, STAFF_ROLES } from '../roles.mjs';
+
+test('isStaffRole allows admin and superadmin only', () => {
+  assert.equal(isStaffRole('admin'), true);
+  assert.equal(isStaffRole('superadmin'), true);
+});
+
+test('isStaffRole rejects non-staff and missing roles', () => {
+  for (const role of ['user', 'manager', 'editor', '', undefined, null]) {
+    assert.equal(isStaffRole(role), false, `role ${String(role)} must be rejected`);
+  }
+});
+
+test('isSuperadmin is stricter than isStaffRole', () => {
+  assert.equal(isSuperadmin('superadmin'), true);
+  assert.equal(isSuperadmin('admin'), false);
+  assert.equal(isSuperadmin('user'), false);
+  assert.equal(isSuperadmin(undefined), false);
+});
+
+test('STAFF_ROLES contains exactly admin and superadmin', () => {
+  assert.deepEqual([...STAFF_ROLES].sort(), ['admin', 'superadmin']);
+});
+
+test('isValidBearer accepts the exact matching bearer token', () => {
+  assert.equal(isValidBearer('Bearer s3cr3t', 's3cr3t'), true);
+});
+
+test('isValidBearer rejects wrong, malformed, or missing tokens', () => {
+  assert.equal(isValidBearer('Bearer wrong', 's3cr3t'), false);
+  assert.equal(isValidBearer('s3cr3t', 's3cr3t'), false);
+  assert.equal(isValidBearer('Bearer ', 's3cr3t'), false);
+  assert.equal(isValidBearer(null, 's3cr3t'), false);
+  assert.equal(isValidBearer(undefined, 's3cr3t'), false);
+});
+
+test('isValidBearer fails closed when server secret is unset', () => {
+  assert.equal(isValidBearer('Bearer anything', ''), false);
+  assert.equal(isValidBearer('Bearer anything', undefined), false);
+  assert.equal(isValidBearer(undefined, undefined), false);
+});

--- a/src/lib/auth/roles.mjs
+++ b/src/lib/auth/roles.mjs
@@ -1,0 +1,24 @@
+// Pure authorization predicates shared by the collection access control, the staff-session
+// guard (src/app/api/staff/_session.ts), the internal/setup route guard
+// (src/app/api/documents/_auth.ts), and the /admin-panel layout. Keeping these as a tiny,
+// dependency-free module lets them be unit-tested with `node --test` without a database,
+// bundler, or next/server import, while guaranteeing the routes and tests agree on the rule.
+
+export const STAFF_ROLES = ['admin', 'superadmin'];
+
+// True only for staff roles that may read/manage lead, order, and customer PII.
+export function isStaffRole(role) {
+  return role === 'admin' || role === 'superadmin';
+}
+
+// True only for superadmin — used for destructive operations (e.g. deleting leads).
+export function isSuperadmin(role) {
+  return role === 'superadmin';
+}
+
+// Bearer-token check for the internal/setup routes. Fails closed when the server has no
+// CRON_SECRET configured, so an unset secret can never authorize a request.
+export function isValidBearer(authHeader, secret) {
+  if (!secret) return false;
+  return authHeader === `Bearer ${secret}`;
+}


### PR DESCRIPTION
## Summary

Blocks unauthenticated exposure of lead / order / customer **PII** across the custom CRM/admin surface. These routes and the `/admin-panel` dashboard previously read data through the Payload **Local API with no auth guard**, so anyone could fetch names, emails, phones, addresses, and conviction data. This PR gates every PII-bearing surface behind the existing staff-session auth model and fails setup/debug routes closed.

Self-contained: includes the **Leads collection access-control fix from PR #11** so #11 can be closed in favor of this PR.

### Auth model chosen
- **Browser dashboard surface** (`/admin-panel`, CRM/PII API routes): authenticate the logged-in Payload user via the session cookie and require an `admin`/`superadmin` role, reusing the existing `requireStaff` guard (`src/app/api/staff/_session.ts`) — the same auth that protects the Payload admin UI. No new/weaker credential introduced. The legacy Supabase pattern in `admin-panel/page.tsx` is client-side only and was **not** left as the security boundary.
- **Setup/debug routes**: require `Bearer CRON_SECRET` (reusing `authorizeInternal`), matching the cron/document routes. Fails closed when `CRON_SECRET` is unset.

### Changes
- **Leads collection** — add access block: `read`/`update` = admin/superadmin, `delete` = superadmin, `create` = true. Public lead capture (`/api/lead`) uses the Local API (overrideAccess) so it is unaffected.
- **`/admin-panel`** — server-component `layout.tsx` gate requires an authenticated staff session; otherwise renders a "sign-in required" screen and never renders the data-fetching children.
- **PII API routes gated with `requireStaff`** (401 unauth / 403 wrong role): `/api/leads`, `/api/leads/[id]`, `/api/orders`, `/api/orders/[id]`, `/api/customers`, `/api/admin-stats`, `/api/dashboard-metrics`, `/api/analytics`.
- **Setup/debug routes gated with Bearer `CRON_SECRET`**: `/api/init-admin` (POST), `/api/init-db`, `/api/init-simple`, `/api/unlock-admin` (POST), `/api/test-db`, `/api/env-check`.
- **Shared predicates** — extracted `isStaffRole` / `isSuperadmin` / `isValidBearer` into `src/lib/auth/roles.mjs`; the Leads access, staff guard, internal guard, and layout all reuse them so routes and tests can't drift.
- **CORS/CSRF** — replaced `https://your-domain.com` placeholder with real origins `https://www.wipethatrecord.com` + apex.

### Intentional non-fixes (kept out to stay small/reviewable)
- Optional `/api/checkout` metadata + webhook lead-dedupe cleanups were **not** included — they are funnel-behavior changes, not PII-exposure fixes, and were not safely testable without a live Stripe/DB. Recommend a separate PR.
- `PAYLOAD_SECRET` empty fallback left as-is (`|| ''`): failing closed there could break the running app if the env var is missing; the safer action is to ensure the env var is set in production. Flagged for ops rather than changed here.
- Public paths deliberately untouched: lead capture, checkout, Stripe webhooks, CRON_SECRET document APIs, and public marketing pages.

## Testing

Added pure unit tests for the security predicates (`src/lib/auth/__tests__/roles.test.mjs`), covering staff-role allow/deny, superadmin-only, and bearer accept/reject incl. **fail-closed when the secret is unset**. Wired into `npm test`.

```
$ node --test src/lib/auth/__tests__/
# tests 7 / pass 7 / fail 0
```

- [x] New auth predicate tests pass (7/7).
- [x] Pre-existing document/CRM `.mjs` tests unaffected by these changes (the 7 failures observed locally are all `Cannot find package 'pdf-lib'` — a missing-dependency artifact of the sandbox, not a code regression).
- [ ] **`tsc --noEmit`, `next build`, and `eslint` could NOT be run locally**: the sandbox disk was 100% full so `npm install`/`npm ci` failed with `ENOSPC`. Relying on the **Vercel preview build + typecheck** triggered by this PR to validate compilation.

### Manual production checks still required
- Confirm the Vercel preview builds cleanly (typecheck/lint/build).
- Verify a logged-in admin/superadmin can still load `/admin-panel` and the gated APIs return data, while a logged-out request gets the sign-in screen / 401-403.
- Confirm `CRON_SECRET` is set in production so the setup/debug routes remain usable by operators and public lead capture + checkout still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)